### PR TITLE
Add Dependabot configuration for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,11 @@ packages/
 
 Contains TypeScript types used by both frontend and backend. Imported as `@quro/shared` via path aliases configured in each package's `tsconfig.json`.
 
+## Pull Requests
+
+- Do not include a link to the Claude session in PR descriptions.
+- The PR description should describe the change in more detail than the title — explain what was changed and why, not just restate the title.
+
 ## Code Conventions
 
 - **ESLint rules to be aware of:** max 50 lines per function, max complexity 10, no floating promises, `readonly` preferred for params, strict equality required. Run `bun run lint` before committing.


### PR DESCRIPTION
Created `.github/dependabot.yml` with two entries:

- `npm` **ecosystem at** `/` — Dependabot detects `bun.lockb` in the repo root and uses Bun to update it, covering all workspace packages (`packages/backend`, `packages/frontend`, `packages/shared`) via the root workspace.
- `github-actions` **ecosystem** — keeps the Actions used in `ci.yml` (`actions/checkout`, `oven-sh/setup-bun`) up to date as well.