### PR TITLE
Add data normalization for budget categories and transactions

### DIFF
--- a/packages/frontend/src/features/budget/hooks/useBudgetCategories.ts
+++ b/packages/frontend/src/features/budget/hooks/useBudgetCategories.ts
@@ -1,13 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from '@/lib/api';
 import type { BudgetCategory } from '../types';
+import { normalizeBudgetCategory } from '../utils/normalizers';
 
 export function useBudgetCategories() {
   return useQuery({
     queryKey: ['budget', 'categories'],
     queryFn: async () => {
       const { data } = await api.get('/api/budget/categories');
-      return data.data as BudgetCategory[];
+      return (data.data as BudgetCategory[]).map(normalizeBudgetCategory);
     },
   });
 }

--- a/packages/frontend/src/features/budget/hooks/useBudgetTransactions.ts
+++ b/packages/frontend/src/features/budget/hooks/useBudgetTransactions.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from '@/lib/api';
 import type { BudgetTx } from '../types';
+import { normalizeBudgetTransaction } from '../utils/normalizers';
 
 export function useBudgetTransactions(categoryId?: number) {
   return useQuery({
@@ -8,7 +9,7 @@ export function useBudgetTransactions(categoryId?: number) {
     queryFn: async () => {
       const params = categoryId ? { categoryId } : {};
       const { data } = await api.get('/api/budget/transactions', { params });
-      return data.data as BudgetTx[];
+      return (data.data as BudgetTx[]).map(normalizeBudgetTransaction);
     },
   });
 }

--- a/packages/frontend/src/features/budget/utils/normalizers.ts
+++ b/packages/frontend/src/features/budget/utils/normalizers.ts
@@ -1,0 +1,25 @@
+import type { BudgetCategory, BudgetTx } from '../types';
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const parsed = parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+export function normalizeBudgetCategory(raw: BudgetCategory): BudgetCategory {
+  return {
+    ...raw,
+    budgeted: toNumber(raw.budgeted),
+    spent: toNumber(raw.spent),
+  };
+}
+
+export function normalizeBudgetTransaction(raw: BudgetTx): BudgetTx {
+  return {
+    ...raw,
+    amount: toNumber(raw.amount),
+  };
+}


### PR DESCRIPTION
## Summary
This PR introduces data normalization utilities for budget-related data to ensure consistent type handling and data integrity when fetching categories and transactions from the API.

## Key Changes
- **New normalizers module** (`packages/frontend/src/features/budget/utils/normalizers.ts`):
  - Added `toNumber()` helper function that safely converts unknown values to numbers, handling strings, numbers, and invalid values (defaults to 0)
  - Added `normalizeBudgetCategory()` to normalize `budgeted` and `spent` fields
  - Added `normalizeBudgetTransaction()` to normalize `amount` field

- **Updated hooks** to apply normalization:
  - `useBudgetCategories`: Maps fetched categories through `normalizeBudgetCategory`
  - `useBudgetTransactions`: Maps fetched transactions through `normalizeBudgetTransaction`

## Implementation Details
The normalization approach ensures that numeric fields are properly typed regardless of how the API returns them (as strings, numbers, or invalid values). This prevents runtime errors and provides a consistent data contract throughout the budget feature.