### PR TITLE
refactor: eliminate redundant queries, reduce duplication in PDF document handling

### DIFF
--- a/packages/backend/src/lib/pdfDocuments.ts
+++ b/packages/backend/src/lib/pdfDocuments.ts
@@ -5,6 +5,13 @@ export const PDF_MIME_TYPE = 'application/pdf' as const;
 export const PDF_EXTENSION = '.pdf';
 export const MAX_PDF_SIZE_BYTES = 20 * 1024 * 1024;
 
+export const CLEAR_INLINE_PDF_DOCUMENT = {
+  documentStorageKey: null,
+  documentFileName: null,
+  documentSizeBytes: null,
+  documentUploadedAt: null,
+};
+
 export type InlinePdfDocumentFields = {
   documentStorageKey: string | null;
   documentFileName: string | null;

--- a/packages/backend/src/routes/pensions.ts
+++ b/packages/backend/src/routes/pensions.ts
@@ -8,6 +8,7 @@ import { getS3ObjectBytes } from '../lib/s3';
 import {
   asFile,
   buildPdfStorageKey,
+  CLEAR_INLINE_PDF_DOCUMENT,
   deleteStoredPdfSafely,
   isS3NotFoundError,
   PDF_MIME_TYPE,
@@ -309,18 +310,6 @@ async function applyPensionPotBalanceDelta(
     .where(and(eq(pensionPots.id, potId), eq(pensionPots.userId, userId)));
 }
 
-async function findOwnedTransactionRow(
-  tx: DbTransaction,
-  userId: number,
-  transactionId: number,
-): Promise<typeof pensionTransactions.$inferSelect | null> {
-  const [transaction] = await tx
-    .select()
-    .from(pensionTransactions)
-    .where(and(eq(pensionTransactions.id, transactionId), eq(pensionTransactions.userId, userId)));
-  return transaction ?? null;
-}
-
 type UploadStatementDocumentResult =
   | { ok: true; document: PensionStatementDocumentRecord }
   | { ok: false; error: string; status: (typeof HTTP_STATUS)[keyof typeof HTTP_STATUS] };
@@ -385,9 +374,16 @@ async function uploadStatementDocumentForTransaction(params: {
   transactionId: number;
   file: File;
 }): Promise<UploadStatementDocumentResult> {
-  const transaction = await db.transaction((tx) =>
-    findOwnedTransactionRow(tx, params.userId, params.transactionId),
-  );
+  const [transactionRow] = await db
+    .select()
+    .from(pensionTransactions)
+    .where(
+      and(
+        eq(pensionTransactions.id, params.transactionId),
+        eq(pensionTransactions.userId, params.userId),
+      ),
+    );
+  const transaction = transactionRow ?? null;
 
   if (!transaction)
     return { ok: false, error: 'Transaction not found', status: HTTP_STATUS.NOT_FOUND };
@@ -496,28 +492,15 @@ async function handleStatementDocumentAfterTransactionUpdate(params: {
   transactionId: number;
   previousType: string;
   nextType: string;
+  existingRow: typeof pensionTransactions.$inferSelect;
 }): Promise<string | null> {
   if (params.previousType === 'annual_statement' && params.nextType !== 'annual_statement') {
-    const [transaction] = await params.tx
-      .select()
-      .from(pensionTransactions)
-      .where(
-        and(
-          eq(pensionTransactions.id, params.transactionId),
-          eq(pensionTransactions.userId, params.userId),
-        ),
-      );
-    const document = transaction ? readInlinePdfDocument(transaction) : null;
+    const document = readInlinePdfDocument(params.existingRow);
     if (!document) return null;
 
     await params.tx
       .update(pensionTransactions)
-      .set({
-        documentStorageKey: null,
-        documentFileName: null,
-        documentSizeBytes: null,
-        documentUploadedAt: null,
-      })
+      .set(CLEAR_INLINE_PDF_DOCUMENT)
       .where(
         and(
           eq(pensionTransactions.id, params.transactionId),
@@ -613,6 +596,7 @@ async function updatePensionTransaction(params: {
       transactionId: params.transactionId,
       previousType: normalizedExisting.type,
       nextType: nextPayload.type,
+      existingRow: existing,
     });
 
     return { data };
@@ -908,12 +892,7 @@ app.delete('/transactions/:id/document', async (c) => {
 
   await db
     .update(pensionTransactions)
-    .set({
-      documentStorageKey: null,
-      documentFileName: null,
-      documentSizeBytes: null,
-      documentUploadedAt: null,
-    })
+    .set(CLEAR_INLINE_PDF_DOCUMENT)
     .where(and(eq(pensionTransactions.userId, user.id), eq(pensionTransactions.id, transactionId)));
 
   await deleteStoredPdfSafely(existingDocument.storageKey, 'pension statement PDF');

--- a/packages/backend/src/routes/salary.ts
+++ b/packages/backend/src/routes/salary.ts
@@ -7,6 +7,7 @@ import { getAuthUser } from '../lib/authUser';
 import {
   asFile,
   buildPdfStorageKey,
+  CLEAR_INLINE_PDF_DOCUMENT,
   deleteStoredPdfSafely,
   formatInlinePdfDocument,
   isS3NotFoundError,
@@ -453,12 +454,7 @@ app.delete('/payslips/:id/document', async (c) => {
 
   await db
     .update(payslips)
-    .set({
-      documentStorageKey: null,
-      documentFileName: null,
-      documentSizeBytes: null,
-      documentUploadedAt: null,
-    })
+    .set(CLEAR_INLINE_PDF_DOCUMENT)
     .where(and(eq(payslips.id, payslipId), eq(payslips.userId, user.id)));
 
   await deleteStoredPdfSafely(deletedDocument.storageKey, 'payslip PDF');

--- a/packages/frontend/src/features/pension/hooks/usePensionImportModalController.ts
+++ b/packages/frontend/src/features/pension/hooks/usePensionImportModalController.ts
@@ -9,8 +9,7 @@ import { usePensionStatementImportRows } from './usePensionStatementImportRows';
 import { useRestorePensionStatementImportRow } from './useRestorePensionStatementImportRow';
 import { useUpdatePensionStatementImportRow } from './useUpdatePensionStatementImportRow';
 import type { UpdatePensionImportRowPayload } from '../types';
-
-const MAX_PDF_SIZE_BYTES = 20 * 1024 * 1024;
+import { validatePdfFile } from '../../../lib/pdfDocuments';
 
 type RowDraft = {
   type: PensionStatementImportRow['type'];
@@ -100,16 +99,6 @@ function toDraft(row: PensionStatementImportRow): RowDraft {
     note: row.note,
     isEmployer: row.isEmployer,
   };
-}
-
-function validateUploadFile(file: File | null): string {
-  if (!file) return 'A PDF file is required';
-  const mimeAllowed = file.type === 'application/pdf' || file.type === '';
-  if (!file.name.toLowerCase().endsWith('.pdf') || !mimeAllowed)
-    return 'Only PDF files are allowed';
-  if (file.size <= 0) return 'Uploaded file is empty';
-  if (file.size > MAX_PDF_SIZE_BYTES) return 'PDF exceeds 20MB limit';
-  return '';
 }
 
 function buildRowPayload(draft: RowDraft): UpdatePensionImportRowPayload {
@@ -331,14 +320,18 @@ function useImportActions({
   };
 
   const handleUpload = async (): Promise<void> => {
-    const validationError = validateUploadFile(selectedFile);
+    if (!selectedFile) {
+      setErrorMessage('A PDF file is required');
+      return;
+    }
+    const validationError = validatePdfFile(selectedFile);
     if (validationError) {
       setErrorMessage(validationError);
       return;
     }
 
     try {
-      const created = await createImport.mutateAsync({ potId, file: selectedFile! });
+      const created = await createImport.mutateAsync({ potId, file: selectedFile });
       setImportId(created.id);
       setErrorMessage('');
       setConfirmMode('none');

--- a/packages/frontend/src/features/salary/hooks/useAddPayslipForm.ts
+++ b/packages/frontend/src/features/salary/hooks/useAddPayslipForm.ts
@@ -27,7 +27,7 @@ export function useAddPayslipForm(baseCurrency: CurrencyCode, existing?: Payslip
   };
 
   const buildPayload = (): SavePayslipInput | null => {
-    const nextErrors = validatePayslipForm(form, gross, tax, pension);
+    const nextErrors = validatePayslipForm(form);
     if (Object.keys(nextErrors).length > 0) {
       setErrors(nextErrors);
       return null;

--- a/packages/frontend/src/features/salary/utils/payslip-form.ts
+++ b/packages/frontend/src/features/salary/utils/payslip-form.ts
@@ -33,12 +33,8 @@ export const computePayslipDraftAmounts = (form: PayslipFormState) => {
   return { gross, tax, pension, bonus, net };
 };
 
-export function validatePayslipForm(
-  form: PayslipFormState,
-  gross: number,
-  tax: number,
-  pension: number,
-): PayslipFieldErrorMap {
+export function validatePayslipForm(form: PayslipFormState): PayslipFieldErrorMap {
+  const { gross, tax, pension } = computePayslipDraftAmounts(form);
   const errors: PayslipFieldErrorMap = {};
 
   if (!form.month.trim()) errors.month = 'Required';

--- a/packages/frontend/src/lib/pdfDocuments.ts
+++ b/packages/frontend/src/lib/pdfDocuments.ts
@@ -44,6 +44,7 @@ export function validatePdfFile(file: File): string {
   const allowedMimeType = file.type === 'application/pdf' || file.type === '';
 
   if (!hasPdfExtension || !allowedMimeType) return 'Only PDF files are allowed';
+  if (file.size <= 0) return 'Uploaded file is empty';
   if (file.size > MAX_PDF_SIZE_BYTES) return 'PDF exceeds 20MB limit';
   return '';
 }


### PR DESCRIPTION
- Remove extra SELECT inside handleStatementDocumentAfterTransactionUpdate by
  passing the already-fetched existing row instead of re-querying the DB
- Eliminate db.transaction() wrapper around a plain SELECT in
  uploadStatementDocumentForTransaction; also remove now-dead findOwnedTransactionRow
- Extract CLEAR_INLINE_PDF_DOCUMENT constant from pdfDocuments lib and use it
  in all three null-out sites (pensions.ts x2, salary.ts)
- Fix validatePayslipForm parameter sprawl by computing gross/tax/pension
  internally from the form instead of requiring callers to pass them
- Replace duplicate validateUploadFile in usePensionImportModalController with
  the shared validatePdfFile from lib/pdfDocuments; extend the shared function
  to also cover the empty-file case