### PR TITLE
Harden GitHub workflow permissions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Pieter-OHearn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   # ── JavaScript / TypeScript ──────────────────────────────────────────────
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,14 @@ on:
         default: 'main'
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 jobs:
   prepare:
     name: Prepare Tag
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       RELEASE_REF: ${{ inputs.ref || 'main' }}
     outputs:
@@ -49,6 +50,9 @@ jobs:
     name: Build & Push Images
     runs-on: ubuntu-latest
     needs: prepare
+    permissions:
+      contents: read
+      packages: write
     env:
       VERSION: ${{ needs.prepare.outputs.version }}
       REGISTRY_OWNER: ${{ github.repository_owner }}
@@ -99,6 +103,8 @@ jobs:
     name: Publish Release
     runs-on: ubuntu-latest
     needs: [prepare, build-images]
+    permissions:
+      contents: write
     env:
       VERSION: ${{ needs.prepare.outputs.version }}
       REGISTRY_OWNER: ${{ github.repository_owner }}


### PR DESCRIPTION
## What does this PR do?

- declares workflow-wide read-only permissions for CI
- scopes release permissions per job so only tagging/publishing steps get write access
- keeps Docker pushes limited to packages scope

## How to test

- not run (workflow-only changes)

## Checklist

- [x] `bun run lint` passes
- [x] `bun run format:check` passes
- [x] `bun run test` passes
- [ ] Any new behaviour is covered by tests