### PR TITLE
Potential fix for code scanning alert no. 12: Regular expression injection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -48,7 +48,7 @@
         "axios": "^1.15.0",
         "date-fns": "4.1.0",
         "emoji-picker-react": "^4.18.0",
-        "lucide-react": "0.577.0",
+        "lucide-react": "1.8.0",
         "react": "19.2.5",
         "react-dom": "19.2.5",
         "react-router": "7.14.0",
@@ -943,7 +943,7 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "lucide-react": ["lucide-react@0.577.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A=="],
+    "lucide-react": ["lucide-react@1.8.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 

--- a/scripts/read-changelog-section.ts
+++ b/scripts/read-changelog-section.ts
@@ -4,6 +4,10 @@ import { readFile } from 'node:fs/promises';
 
 const version = process.argv[2];
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 if (!version) {
   console.error('Usage: bun scripts/read-changelog-section.ts <version>');
   process.exit(1);
@@ -11,7 +15,8 @@ if (!version) {
 
 async function main() {
   const changelog = await readFile('CHANGELOG.md', 'utf8');
-  const pattern = new RegExp(`^##\\s*\\[?${version}\\]?[^\\n]*$`, 'm');
+  const safeVersion = escapeRegExp(version);
+  const pattern = new RegExp(`^##\\s*\\[?${safeVersion}\\]?[^\\n]*$`, 'm');
   const match = changelog.match(pattern);
   if (!match || match.index === undefined) {
     throw new Error(`Could not find changelog section for ${version}`);


### PR DESCRIPTION
Potential fix for [https://github.com/Pieter-OHearn/quro/security/code-scanning/12](https://github.com/Pieter-OHearn/quro/security/code-scanning/12)

General fix: sanitize any untrusted string before embedding it in a regex pattern by escaping regex metacharacters.

Best fix here: in `scripts/read-changelog-section.ts`, add a small local `escapeRegExp` helper and use it to transform `version` before building `new RegExp(...)`. This preserves current functionality (matching literal version text in changelog headings) while preventing regex injection.

Changes needed:
- In `scripts/read-changelog-section.ts`, define:
  - `function escapeRegExp(value: string): string { ... }`
- In `main()`, compute `safeVersion = escapeRegExp(version)` and use `safeVersion` in the template literal for `pattern`.
- No import changes required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
