### PR TITLE
Export discriminant const arrays from @quro/shared; fix pension pot type validation

### DIFF
--- a/packages/backend/src/routes/finance.integration.test.ts
+++ b/packages/backend/src/routes/finance.integration.test.ts
@@ -1669,7 +1669,7 @@ describe('finance integration', () => {
       json: {
         name: 'Workplace Pension',
         provider: 'Aviva',
-        type: 'workplace',
+        type: 'Workplace Pension',
         balance: 12000,
         currency: 'GBP',
         employeeMonthly: 200,

--- a/packages/backend/src/routes/finance.integration.test.ts
+++ b/packages/backend/src/routes/finance.integration.test.ts
@@ -988,7 +988,7 @@ describe('finance integration', () => {
       json: {
         name: 'Work Pension',
         provider: 'Aegon',
-        type: 'defined_contribution',
+        type: 'Workplace Pension',
         balance: 10000,
         currency: 'GBP',
         employeeMonthly: 200,
@@ -1010,7 +1010,7 @@ describe('finance integration', () => {
       json: {
         name: 'Old Employer Pension',
         provider: 'Vanguard',
-        type: 'defined_contribution',
+        type: 'Workplace Pension',
         balance: 2000,
         currency: 'EUR',
         employeeMonthly: 0,
@@ -1031,7 +1031,7 @@ describe('finance integration', () => {
       json: {
         name: 'Foreign Pot',
         provider: 'Other',
-        type: 'defined_contribution',
+        type: 'Personal Pension',
         balance: 500,
         currency: 'USD',
         employeeMonthly: 10,
@@ -1458,7 +1458,7 @@ describe('finance integration', () => {
       json: {
         name: 'Broken Pot',
         provider: 'Aegon',
-        type: 'defined_contribution',
+        type: 'Workplace Pension',
         balance: 1000,
         currency: 'EUR',
         employeeMonthly: 50,
@@ -1485,7 +1485,7 @@ describe('finance integration', () => {
       json: {
         name: 'Valid Pot',
         provider: 'Aegon',
-        type: 'defined_contribution',
+        type: 'Workplace Pension',
         balance: 5000,
         currency: 'EUR',
         employeeMonthly: 100,

--- a/packages/backend/src/routes/investments.ts
+++ b/packages/backend/src/routes/investments.ts
@@ -1,7 +1,11 @@
 import { Hono } from 'hono';
 import {
+  HOLDING_TRANSACTION_TYPES,
+  PROPERTY_TRANSACTION_TYPES,
   parseTickerItemType,
   type CurrencyCode,
+  type HoldingTransactionType,
+  type PropertyTransactionType,
   type TickerItemType,
   type TickerLookupExchange,
   type TickerLookupResult,
@@ -85,8 +89,6 @@ const PROPERTY_TRANSACTION_FIELDS = [
   'date',
   'note',
 ] as const;
-const HOLDING_TRANSACTION_TYPES = ['buy', 'sell', 'dividend'] as const;
-const PROPERTY_TRANSACTION_TYPES = ['repayment', 'valuation', 'rent_income', 'expense'] as const;
 const INVESTMENT_PROPERTY_TYPE_KEYS = new Set([
   'buy-to-let',
   'investment',
@@ -157,9 +159,6 @@ function parseHoldingPriceHistoryQuery(input: {
     },
   };
 }
-
-type HoldingTransactionType = (typeof HOLDING_TRANSACTION_TYPES)[number];
-type PropertyTransactionType = (typeof PROPERTY_TRANSACTION_TYPES)[number];
 
 type HoldingPayload = {
   name: string;

--- a/packages/backend/src/routes/mortgages.ts
+++ b/packages/backend/src/routes/mortgages.ts
@@ -1,5 +1,9 @@
 import { Hono } from 'hono';
-import type { CurrencyCode } from '@quro/shared';
+import {
+  MORTGAGE_TRANSACTION_TYPES,
+  type CurrencyCode,
+  type MortgageTransactionType,
+} from '@quro/shared';
 import { db } from '../db/client';
 import { mortgages, mortgageTransactions, properties } from '../db/schema';
 import { and, eq, isNull } from 'drizzle-orm';
@@ -51,10 +55,7 @@ const MORTGAGE_TRANSACTION_FIELDS = [
   'note',
   'fixedYears',
 ] as const;
-const MORTGAGE_TRANSACTION_TYPES = ['repayment', 'valuation', 'rate_change'] as const;
-
 type MortgageRateType = 'Fixed' | 'Variable';
-type MortgageTransactionType = (typeof MORTGAGE_TRANSACTION_TYPES)[number];
 
 type MortgagePayload = {
   linkedPropertyId: number;

--- a/packages/backend/src/routes/pensions.ts
+++ b/packages/backend/src/routes/pensions.ts
@@ -1,5 +1,11 @@
 import { Hono } from 'hono';
-import type { CurrencyCode } from '@quro/shared';
+import {
+  PENSION_POT_TYPES,
+  PENSION_TRANSACTION_TYPES,
+  type CurrencyCode,
+  type PensionPotType,
+  type PensionTransactionType,
+} from '@quro/shared';
 import { db } from '../db/client';
 import { pensionPots, pensionTransactions } from '../db/schema';
 import { and, eq, isNotNull, isNull, sql } from 'drizzle-orm';
@@ -36,7 +42,6 @@ import {
 } from '../lib/requestValidation';
 
 const app = new Hono();
-const TRANSACTION_TYPES = ['contribution', 'fee', 'annual_statement'] as const;
 const PENSION_POT_FIELDS = [
   'name',
   'provider',
@@ -61,12 +66,10 @@ const PENSION_TRANSACTION_FIELDS = [
   'isEmployer',
 ] as const;
 
-type PensionTransactionType = (typeof TRANSACTION_TYPES)[number];
-
 type PensionPotPayload = {
   name: string;
   provider: string;
-  type: string;
+  type: PensionPotType;
   balance: number;
   currency: CurrencyCode;
   employeeMonthly: number;
@@ -158,7 +161,10 @@ function parseMetadataField(value: unknown): ParseResult<Record<string, string>>
 const pensionPotParsers: FieldParsers<PensionPotPayload> = {
   name: (value) => parseTextField(value, 'Pension name is required'),
   provider: (value) => parseTextField(value, 'Provider is required'),
-  type: (value) => parseTextField(value, 'Pension type is required'),
+  type: (value) =>
+    typeof value === 'string' && PENSION_POT_TYPES.includes(value as PensionPotType)
+      ? ok(value as PensionPotType)
+      : err('Invalid pension type'),
   balance: (value) => parseNumberField(value, 'Balance must be zero or greater', 0),
   currency: parseCurrencyField,
   employeeMonthly: (value) =>
@@ -250,7 +256,7 @@ function toFiniteNumber(value: unknown): number | null {
 
 function parsePensionTransactionType(value: unknown): PensionTransactionType | null {
   if (typeof value !== 'string') return null;
-  return TRANSACTION_TYPES.includes(value as PensionTransactionType)
+  return PENSION_TRANSACTION_TYPES.includes(value as PensionTransactionType)
     ? (value as PensionTransactionType)
     : null;
 }

--- a/packages/backend/src/routes/savings.ts
+++ b/packages/backend/src/routes/savings.ts
@@ -1,5 +1,11 @@
 import { and, eq, isNull } from 'drizzle-orm';
 import { Hono } from 'hono';
+import {
+  SAVINGS_ACCOUNT_TYPES,
+  SAVINGS_TRANSACTION_TYPES,
+  type SavingsAccountType,
+  type SavingsTransactionType,
+} from '@quro/shared';
 import { HTTP_STATUS } from '../constants/http';
 import { db } from '../db/client';
 import { savingsAccounts, savingsTransactions } from '../db/schema';
@@ -41,11 +47,6 @@ const SAVINGS_ACCOUNT_FIELDS = [
   'emoji',
 ] as const;
 const SAVINGS_TRANSACTION_FIELDS = ['accountId', 'type', 'amount', 'date', 'note'] as const;
-const SAVINGS_ACCOUNT_TYPES = ['Easy Access', 'Term Deposit'] as const;
-const SAVINGS_TRANSACTION_TYPES = ['deposit', 'withdrawal', 'interest'] as const;
-
-type SavingsAccountType = (typeof SAVINGS_ACCOUNT_TYPES)[number];
-type SavingsTransactionType = (typeof SAVINGS_TRANSACTION_TYPES)[number];
 
 type SavingsAccountPayload = {
   name: string;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -83,6 +83,9 @@ export type UpdateUserPasswordInput = {
   nextPassword: string;
 };
 
+export const SAVINGS_ACCOUNT_TYPES = ['Easy Access', 'Term Deposit'] as const;
+export type SavingsAccountType = (typeof SAVINGS_ACCOUNT_TYPES)[number];
+
 export type SavingsAccount = {
   id: number;
   name: string;
@@ -90,17 +93,20 @@ export type SavingsAccount = {
   balance: number;
   currency: CurrencyCode;
   interestRate: number;
-  accountType: 'Easy Access' | 'Term Deposit';
+  accountType: SavingsAccountType;
   color: string;
   emoji: string;
   bunqAccountId?: string | null;
   archivedAt?: string | null;
 };
 
+export const SAVINGS_TRANSACTION_TYPES = ['deposit', 'withdrawal', 'interest'] as const;
+export type SavingsTransactionType = (typeof SAVINGS_TRANSACTION_TYPES)[number];
+
 export type SavingsTransaction = {
   id: number;
   accountId: number;
-  type: 'deposit' | 'withdrawal' | 'interest';
+  type: SavingsTransactionType;
   amount: number;
   date: string;
   note: string;
@@ -214,10 +220,13 @@ export type Holding = {
   archivedAt?: string | null;
 };
 
+export const HOLDING_TRANSACTION_TYPES = ['buy', 'sell', 'dividend'] as const;
+export type HoldingTransactionType = (typeof HOLDING_TRANSACTION_TYPES)[number];
+
 export type HoldingTransaction = {
   id: number;
   holdingId: number;
-  type: 'buy' | 'sell' | 'dividend';
+  type: HoldingTransactionType;
   shares: number | null;
   price: number;
   date: string;
@@ -247,10 +256,18 @@ export type Property = {
   emoji: string;
 };
 
+export const PROPERTY_TRANSACTION_TYPES = [
+  'repayment',
+  'valuation',
+  'rent_income',
+  'expense',
+] as const;
+export type PropertyTransactionType = (typeof PROPERTY_TRANSACTION_TYPES)[number];
+
 export type PropertyTransaction = {
   id: number;
   propertyId: number;
-  type: 'repayment' | 'valuation' | 'rent_income' | 'expense';
+  type: PropertyTransactionType;
   amount: number;
   interest: number | null;
   principal: number | null;
@@ -258,11 +275,19 @@ export type PropertyTransaction = {
   note: string;
 };
 
+export const PENSION_POT_TYPES = [
+  'Workplace Pension',
+  'Personal Pension',
+  'State Pension',
+  'Other',
+] as const;
+export type PensionPotType = (typeof PENSION_POT_TYPES)[number];
+
 export type PensionPot = {
   id: number;
   name: string;
   provider: string;
-  type: 'Workplace Pension' | 'Personal Pension' | 'State Pension' | 'Other';
+  type: PensionPotType;
   balance: number;
   currency: CurrencyCode;
   employeeMonthly: number;
@@ -275,10 +300,13 @@ export type PensionPot = {
   archivedAt?: string | null;
 };
 
+export const PENSION_TRANSACTION_TYPES = ['contribution', 'fee', 'annual_statement'] as const;
+export type PensionTransactionType = (typeof PENSION_TRANSACTION_TYPES)[number];
+
 export type PensionTransaction = {
   id: number;
   potId: number;
-  type: 'contribution' | 'fee' | 'annual_statement';
+  type: PensionTransactionType;
   amount: number;
   taxAmount: number;
   date: string;
@@ -424,10 +452,13 @@ export type Mortgage = {
   archivedAt?: string | null;
 };
 
+export const MORTGAGE_TRANSACTION_TYPES = ['repayment', 'valuation', 'rate_change'] as const;
+export type MortgageTransactionType = (typeof MORTGAGE_TRANSACTION_TYPES)[number];
+
 export type MortgageTransaction = {
   id: number;
   mortgageId: number;
-  type: 'repayment' | 'valuation' | 'rate_change';
+  type: MortgageTransactionType;
   amount: number;
   interest: number | null;
   principal: number | null;


### PR DESCRIPTION
Replaces inline string literal unions for PensionPot.type,
SavingsAccount.accountType, SavingsTransaction.type, PensionTransaction.type,
HoldingTransaction.type, PropertyTransaction.type, and MortgageTransaction.type
with exported `as const` arrays and derived type aliases following the existing
GOAL_TYPES / DEBT_TYPES pattern.

Backend routes now import the shared arrays directly instead of redeclaring
them locally. Adds proper enum validation for pensionPotParsers.type, which
previously accepted any non-empty string, allowing invalid values to be stored
in the database.

Fixes #100