### PR TITLE
fix(budget): scope cache invalidation on create mutations to affected month/year

### DIFF
--- a/packages/frontend/src/features/budget/hooks/useCreateBudgetCategory.ts
+++ b/packages/frontend/src/features/budget/hooks/useCreateBudgetCategory.ts
@@ -10,8 +10,13 @@ export function useCreateBudgetCategory() {
       const { data } = await api.post('/api/budget/categories', category);
       return data.data;
     },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['budget'] });
+    onSuccess: (_, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: ['budget', 'categories', variables.month, variables.year],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ['budget', 'transactions', variables.month, variables.year],
+      });
       void queryClient.invalidateQueries({ queryKey: ['dashboard'] });
     },
   });

--- a/packages/frontend/src/features/budget/hooks/useCreateBudgetTransaction.ts
+++ b/packages/frontend/src/features/budget/hooks/useCreateBudgetTransaction.ts
@@ -1,7 +1,25 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { formatBudgetMonthFromDate } from '@quro/shared';
+import { BUDGET_MONTHS, formatBudgetMonthFromDate, type BudgetMonth } from '@quro/shared';
 import { api } from '@/lib/api';
 import type { CreateBudgetTransactionInput } from '../types';
+
+const ISO_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+const MONTH_INDEX_OFFSET = 1;
+
+function getBudgetPeriodFromDate(date: string): { month: BudgetMonth; year: number } {
+  const match = ISO_DATE_PATTERN.exec(date);
+  if (match) {
+    const [, rawYear, rawMonth] = match;
+    const monthIndex = Number(rawMonth) - MONTH_INDEX_OFFSET;
+    const month = BUDGET_MONTHS[monthIndex];
+    if (month) {
+      return { month, year: Number(rawYear) };
+    }
+  }
+
+  const parsedDate = new Date(date);
+  return { month: formatBudgetMonthFromDate(parsedDate), year: parsedDate.getFullYear() };
+}
 
 export function useCreateBudgetTransaction() {
   const queryClient = useQueryClient();
@@ -12,9 +30,7 @@ export function useCreateBudgetTransaction() {
       return data.data;
     },
     onSuccess: (_, variables) => {
-      const d = new Date(variables.date);
-      const month = formatBudgetMonthFromDate(d);
-      const year = d.getFullYear();
+      const { month, year } = getBudgetPeriodFromDate(variables.date);
       void queryClient.invalidateQueries({
         queryKey: ['budget', 'categories', month, year],
       });

--- a/packages/frontend/src/features/budget/hooks/useCreateBudgetTransaction.ts
+++ b/packages/frontend/src/features/budget/hooks/useCreateBudgetTransaction.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { formatBudgetMonthFromDate } from '@quro/shared';
 import { api } from '@/lib/api';
 import type { CreateBudgetTransactionInput } from '../types';
 
@@ -10,8 +11,16 @@ export function useCreateBudgetTransaction() {
       const { data } = await api.post('/api/budget/transactions', transaction);
       return data.data;
     },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['budget'] });
+    onSuccess: (_, variables) => {
+      const d = new Date(variables.date);
+      const month = formatBudgetMonthFromDate(d);
+      const year = d.getFullYear();
+      void queryClient.invalidateQueries({
+        queryKey: ['budget', 'categories', month, year],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ['budget', 'transactions', month, year],
+      });
       void queryClient.invalidateQueries({ queryKey: ['dashboard'] });
     },
   });

--- a/packages/frontend/src/features/budget/hooks/useDeleteBudgetCategory.ts
+++ b/packages/frontend/src/features/budget/hooks/useDeleteBudgetCategory.ts
@@ -9,6 +9,7 @@ export function useDeleteBudgetCategory() {
       await api.delete(`/api/budget/categories/${id}`);
     },
     onSuccess: () => {
+      // id-only input carries no month/year; broad invalidation until input type is extended
       void queryClient.invalidateQueries({ queryKey: ['budget'] });
       void queryClient.invalidateQueries({ queryKey: ['dashboard'] });
     },

--- a/packages/frontend/src/features/budget/hooks/useDeleteBudgetTransaction.ts
+++ b/packages/frontend/src/features/budget/hooks/useDeleteBudgetTransaction.ts
@@ -9,6 +9,7 @@ export function useDeleteBudgetTransaction() {
       await api.delete(`/api/budget/transactions/${id}`);
     },
     onSuccess: () => {
+      // id-only input carries no month/year; broad invalidation until input type is extended
       void queryClient.invalidateQueries({ queryKey: ['budget'] });
       void queryClient.invalidateQueries({ queryKey: ['dashboard'] });
     },

--- a/packages/frontend/src/features/budget/hooks/useUpdateBudgetCategory.ts
+++ b/packages/frontend/src/features/budget/hooks/useUpdateBudgetCategory.ts
@@ -11,6 +11,7 @@ export function useUpdateBudgetCategory() {
       return data.data;
     },
     onSuccess: () => {
+      // id-only input carries no month/year; broad invalidation until input type is extended
       void queryClient.invalidateQueries({ queryKey: ['budget'] });
       void queryClient.invalidateQueries({ queryKey: ['dashboard'] });
     },

--- a/packages/frontend/src/features/budget/hooks/useUpdateBudgetTransaction.ts
+++ b/packages/frontend/src/features/budget/hooks/useUpdateBudgetTransaction.ts
@@ -9,6 +9,7 @@ export function useUpdateBudgetTransaction() {
       return data.data;
     },
     onSuccess: () => {
+      // id-only input carries no month/year; broad invalidation until input type is extended
       void queryClient.invalidateQueries({ queryKey: ['budget'] });
       void queryClient.invalidateQueries({ queryKey: ['dashboard'] });
     },


### PR DESCRIPTION
useCreateBudgetCategory and useCreateBudgetTransaction now invalidate only the
['budget', 'categories', month, year] and ['budget', 'transactions', month, year]
keys instead of the entire ['budget'] prefix. The create inputs carry enough
context (month/year on category; date on transaction, derived via
formatBudgetMonthFromDate) to target precisely.

The four update/delete hooks retain broad invalidation because their id-only
inputs carry no period context; a comment marks these for a follow-up that
extends their input types.

Closes #103