### PR TITLE
fix: evict stale entries from rate limiter store to prevent memory leak

### DIFF
--- a/packages/backend/src/middleware/rateLimit.ts
+++ b/packages/backend/src/middleware/rateLimit.ts
@@ -4,6 +4,15 @@ import { HTTP_STATUS } from '../constants/http';
 function createRateLimiter(windowMs: number, max: number) {
   const store = new Map<string, number[]>();
 
+  const cleanup = setInterval(() => {
+    const cutoff = Date.now() - windowMs;
+    for (const [ip, hits] of store.entries()) {
+      if (hits.every((t) => t <= cutoff)) store.delete(ip);
+    }
+  }, windowMs);
+
+  if (cleanup.unref) cleanup.unref();
+
   return createMiddleware(async (c, next) => {
     if (process.env.NODE_ENV === 'test') {
       await next();


### PR DESCRIPTION
## Summary

- `createRateLimiter` accumulated one Map entry per unique client IP and never removed them, causing unbounded memory growth on long-lived server processes
- Adds a `setInterval` cleanup inside each limiter instance that deletes entries whose entire hit array has expired, running once per window period
- Calls `.unref()` on the interval so it does not block process exit in test environments

## Test plan

- [ ] `bun run test` passes (existing `NODE_ENV === 'test'` bypass is unaffected)
- [ ] `bun run lint` passes
- [ ] Verify that after one full window period, a previously-seen IP's entry is absent from the store

Closes #102

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jg7wjF5cvb1nQXdurnB1cE)_