### PR TITLE
Equalise signin password verification timing

### DIFF
--- a/packages/backend/src/routes/auth.signin.test.ts
+++ b/packages/backend/src/routes/auth.signin.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const AUTH_ROUTE_PATH = join(import.meta.dir, 'auth.ts');
+
+describe('signin handler hardening', () => {
+  const authRoute = readFileSync(AUTH_ROUTE_PATH, 'utf8');
+
+  test('verifies a password hash even when the email is unknown', () => {
+    expect(authRoute).toContain('DUMMY_PASSWORD_HASH');
+    expect(authRoute).toContain('user?.passwordHash ?? DUMMY_PASSWORD_HASH');
+    expect(authRoute).not.toMatch(
+      /if \(!user\) \{\s*return c\.json\(\{ error: 'Invalid email or password' \}/,
+    );
+  });
+
+  test('selects only fields needed for password verification', () => {
+    expect(authRoute).toContain('select({ id: users.id, passwordHash: users.passwordHash })');
+    expect(authRoute).not.toContain('db.select().from(users).where(eq(users.email, email))');
+  });
+});

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -30,6 +30,11 @@ const HOURS_PER_DAY = 24;
 const MINUTES_PER_HOUR = 60;
 const SECONDS_PER_MINUTE = 60;
 const MILLISECONDS_PER_SECOND = 1000;
+const BCRYPT_COST = 10;
+const DUMMY_PASSWORD_HASH = await Bun.password.hash('quro-dummy-password', {
+  algorithm: 'bcrypt',
+  cost: BCRYPT_COST,
+});
 
 type SignUpPayload = {
   firstName: string;
@@ -201,7 +206,10 @@ app.post('/signup', signupRateLimit, async (c) => {
     return c.json({ error: 'An account with this email already exists' }, HTTP_STATUS.CONFLICT);
   }
 
-  const passwordHash = await Bun.password.hash(data.password, { algorithm: 'bcrypt', cost: 10 });
+  const passwordHash = await Bun.password.hash(data.password, {
+    algorithm: 'bcrypt',
+    cost: BCRYPT_COST,
+  });
 
   const [user] = await db
     .insert(users)
@@ -234,13 +242,15 @@ app.post('/signin', signinRateLimit, async (c) => {
     return c.json({ error: 'Email and password are required' }, HTTP_STATUS.BAD_REQUEST);
   }
 
-  const [user] = await db.select().from(users).where(eq(users.email, email));
-  if (!user) {
-    return c.json({ error: 'Invalid email or password' }, HTTP_STATUS.UNAUTHORIZED);
-  }
+  const [user] = await db
+    .select({ id: users.id, passwordHash: users.passwordHash })
+    .from(users)
+    .where(eq(users.email, email));
 
-  const valid = await Bun.password.verify(password, user.passwordHash);
-  if (!valid) {
+  const hashToVerify = user?.passwordHash ?? DUMMY_PASSWORD_HASH;
+  const valid = await Bun.password.verify(password, hashToVerify);
+
+  if (!user || !valid) {
     return c.json({ error: 'Invalid email or password' }, HTTP_STATUS.UNAUTHORIZED);
   }
 


### PR DESCRIPTION
## Summary
- Removes the early return from `POST /api/auth/signin` when an email is unknown.
- Verifies against a module-level dummy bcrypt hash for unknown users, so unknown-email and wrong-password paths both perform password verification.
- Narrows the signin lookup to only `id` and `passwordHash`.
- Adds a regression test guarding the signin hardening pattern.

## Validation
- Static hardening check: confirms dummy hash, unconditional hash selection, minimal credential select, and no early unknown-user return.
- `bun run format:check`
- `bun run lint` — passes with existing warnings only
- `bun run typecheck`
- `bun run build`

## Notes
- Local `bun test` is not usable on this VM at the moment: Bun 1.3.14 crashes with an illegal-instruction/segfault because the VM CPU lacks AVX. GitHub Actions is the source of truth for the test run.

Closes #111

@Pieter-OHearn please review when ready.