### PR TITLE
feat(partner): add joint assets shared between linked partner accounts

### DIFF
--- a/packages/backend/src/db/migrations/0017_fancy_riptide.sql
+++ b/packages/backend/src/db/migrations/0017_fancy_riptide.sql
@@ -1,0 +1,19 @@
+CREATE TYPE "public"."partner_link_status" AS ENUM('pending', 'accepted');--> statement-breakpoint
+CREATE TABLE "partner_links" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"requester_id" integer NOT NULL,
+	"addressee_id" integer NOT NULL,
+	"status" "partner_link_status" DEFAULT 'pending' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"responded_at" timestamp,
+	CONSTRAINT "partner_links_no_self_link_check" CHECK ("partner_links"."requester_id" <> "partner_links"."addressee_id")
+);
+--> statement-breakpoint
+ALTER TABLE "mortgages" ADD COLUMN "is_joint" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "properties" ADD COLUMN "is_joint" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "savings_accounts" ADD COLUMN "is_joint" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "partner_links" ADD CONSTRAINT "partner_links_requester_id_users_id_fk" FOREIGN KEY ("requester_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "partner_links" ADD CONSTRAINT "partner_links_addressee_id_users_id_fk" FOREIGN KEY ("addressee_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "partner_links_requester_id_unique" ON "partner_links" USING btree ("requester_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "partner_links_addressee_id_unique" ON "partner_links" USING btree ("addressee_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "partner_links_pair_unique" ON "partner_links" USING btree (LEAST("requester_id", "addressee_id"), GREATEST("requester_id", "addressee_id"));

--- a/packages/backend/src/db/migrations/meta/0017_snapshot.json
+++ b/packages/backend/src/db/migrations/meta/0017_snapshot.json
@@ -1,0 +1,3728 @@
+{
+  "id": "7eed5554-aa5b-439b-ab62-d7920bc52d0c",
+  "prevId": "aa7d7866-974f-4070-9241-84c7683254cc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.budget_categories": {
+      "name": "budget_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budgeted": {
+          "name": "budgeted",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spent": {
+          "name": "spent",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "budget_categories_user_id_idx": {
+          "name": "budget_categories_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budget_categories_user_month_name_unique": {
+          "name": "budget_categories_user_month_name_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budget_categories_user_id_users_id_fk": {
+          "name": "budget_categories_user_id_users_id_fk",
+          "tableFrom": "budget_categories",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budget_transactions": {
+      "name": "budget_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bunq_transaction_id": {
+          "name": "bunq_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bunq_mcc": {
+          "name": "bunq_mcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bunq_payment_type": {
+          "name": "bunq_payment_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_provider": {
+          "name": "source_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_account_id": {
+          "name": "source_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_account_name": {
+          "name": "source_account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_account_type": {
+          "name": "source_account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_iban": {
+          "name": "counterparty_iban",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "budget_transactions_user_id_idx": {
+          "name": "budget_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budget_transactions_user_date_idx": {
+          "name": "budget_transactions_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budget_transactions_user_bunq_transaction_id_unique": {
+          "name": "budget_transactions_user_bunq_transaction_id_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bunq_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budget_transactions_user_id_users_id_fk": {
+          "name": "budget_transactions_user_id_users_id_fk",
+          "tableFrom": "budget_transactions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "budget_transactions_category_id_budget_categories_id_fk": {
+          "name": "budget_transactions_category_id_budget_categories_id_fk",
+          "tableFrom": "budget_transactions",
+          "tableTo": "budget_categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bunq_connections": {
+      "name": "bunq_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_token": {
+          "name": "installation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_public_key": {
+          "name": "server_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_expires_at": {
+          "name": "session_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bunq_user_id": {
+          "name": "bunq_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "bunq_sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bunq_connections_user_id_idx": {
+          "name": "bunq_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bunq_connections_user_id_users_id_fk": {
+          "name": "bunq_connections_user_id_users_id_fk",
+          "tableFrom": "bunq_connections",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_mappings": {
+      "name": "category_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_name": {
+          "name": "category_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "category_mappings_user_id_idx": {
+          "name": "category_mappings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "category_mappings_user_source_key_unique": {
+          "name": "category_mappings_user_source_key_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "category_mappings_user_id_users_id_fk": {
+          "name": "category_mappings_user_id_users_id_fk",
+          "tableFrom": "category_mappings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.currency_rates": {
+      "name": "currency_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_currency": {
+          "name": "from_currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_currency": {
+          "name": "to_currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_date": {
+          "name": "source_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "currency_rates_from_to_unique": {
+          "name": "currency_rates_from_to_unique",
+          "columns": [
+            {
+              "expression": "from_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_transactions": {
+      "name": "dashboard_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dashboard_transactions_user_id_idx": {
+          "name": "dashboard_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboard_transactions_user_date_idx": {
+          "name": "dashboard_transactions_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboard_transactions_user_id_users_id_fk": {
+          "name": "dashboard_transactions_user_id_users_id_fk",
+          "tableFrom": "dashboard_transactions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.debt_payments": {
+      "name": "debt_payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "debt_id": {
+          "name": "debt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal": {
+          "name": "principal",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest": {
+          "name": "interest",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "debt_payments_user_id_idx": {
+          "name": "debt_payments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "debt_payments_user_date_idx": {
+          "name": "debt_payments_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "debt_payments_debt_id_idx": {
+          "name": "debt_payments_debt_id_idx",
+          "columns": [
+            {
+              "expression": "debt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "debt_payments_user_id_users_id_fk": {
+          "name": "debt_payments_user_id_users_id_fk",
+          "tableFrom": "debt_payments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "debt_payments_debt_id_debts_id_fk": {
+          "name": "debt_payments_debt_id_debts_id_fk",
+          "tableFrom": "debt_payments",
+          "tableTo": "debts",
+          "columnsFrom": ["debt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.debts": {
+      "name": "debts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lender": {
+          "name": "lender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_amount": {
+          "name": "original_amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remaining_balance": {
+          "name": "remaining_balance",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest_rate": {
+          "name": "interest_rate",
+          "type": "numeric(7, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthly_payment": {
+          "name": "monthly_payment",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "debts_user_id_idx": {
+          "name": "debts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "debts_user_id_users_id_fk": {
+          "name": "debts_user_id_users_id_fk",
+          "tableFrom": "debts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_amount": {
+          "name": "current_amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_amount": {
+          "name": "target_amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthly_contribution": {
+          "name": "monthly_contribution",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthly_target": {
+          "name": "monthly_target",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "months_completed": {
+          "name": "months_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_months": {
+          "name": "total_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "start_month": {
+          "name": "start_month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "missed_months": {
+          "name": "missed_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "goals_user_id_idx": {
+          "name": "goals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "goals_source_idx": {
+          "name": "goals_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "goals_user_id_users_id_fk": {
+          "name": "goals_user_id_users_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "goals_source_type_check": {
+          "name": "goals_source_type_check",
+          "value": "\"goals\".\"source_type\" in ('manual', 'salary_latest_gross', 'savings_account', 'portfolio_total', 'net_worth_total', 'invest_habit_buys')"
+        },
+        "goals_source_id_check": {
+          "name": "goals_source_id_check",
+          "value": "((\"goals\".\"source_type\" = 'savings_account' and \"goals\".\"source_id\" is not null and \"goals\".\"source_id\" > 0) or (\"goals\".\"source_type\" <> 'savings_account' and \"goals\".\"source_id\" is null))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.holding_price_history": {
+      "name": "holding_price_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "holding_id": {
+          "name": "holding_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eod_date": {
+          "name": "eod_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "close_price": {
+          "name": "close_price",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_currency": {
+          "name": "price_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "holding_price_history_user_date_idx": {
+          "name": "holding_price_history_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eod_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "holding_price_history_holding_date_idx": {
+          "name": "holding_price_history_holding_date_idx",
+          "columns": [
+            {
+              "expression": "holding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eod_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "holding_price_history_holding_date_unique": {
+          "name": "holding_price_history_holding_date_unique",
+          "columns": [
+            {
+              "expression": "holding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eod_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "holding_price_history_user_id_users_id_fk": {
+          "name": "holding_price_history_user_id_users_id_fk",
+          "tableFrom": "holding_price_history",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "holding_price_history_holding_id_holdings_id_fk": {
+          "name": "holding_price_history_holding_id_holdings_id_fk",
+          "tableFrom": "holding_price_history",
+          "tableTo": "holdings",
+          "columnsFrom": ["holding_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.holding_transactions": {
+      "name": "holding_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "holding_id": {
+          "name": "holding_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shares": {
+          "name": "shares",
+          "type": "numeric(19, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "holding_transactions_user_id_idx": {
+          "name": "holding_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "holding_transactions_user_date_idx": {
+          "name": "holding_transactions_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "holding_transactions_user_id_users_id_fk": {
+          "name": "holding_transactions_user_id_users_id_fk",
+          "tableFrom": "holding_transactions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "holding_transactions_holding_id_holdings_id_fk": {
+          "name": "holding_transactions_holding_id_holdings_id_fk",
+          "tableFrom": "holding_transactions",
+          "tableTo": "holdings",
+          "columnsFrom": ["holding_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.holdings": {
+      "name": "holdings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_price": {
+          "name": "current_price",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sector": {
+          "name": "sector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_mic": {
+          "name": "exchange_mic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industry": {
+          "name": "industry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_updated_at": {
+          "name": "price_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_price": {
+          "name": "manual_price",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclude_from_sync": {
+          "name": "exclude_from_sync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "holdings_user_id_idx": {
+          "name": "holdings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "holdings_user_id_users_id_fk": {
+          "name": "holdings_user_id_users_id_fk",
+          "tableFrom": "holdings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mortgage_transactions": {
+      "name": "mortgage_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mortgage_id": {
+          "name": "mortgage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest": {
+          "name": "interest",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal": {
+          "name": "principal",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fixed_years": {
+          "name": "fixed_years",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mortgage_transactions_user_id_idx": {
+          "name": "mortgage_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mortgage_transactions_user_date_idx": {
+          "name": "mortgage_transactions_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mortgage_transactions_user_id_users_id_fk": {
+          "name": "mortgage_transactions_user_id_users_id_fk",
+          "tableFrom": "mortgage_transactions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "mortgage_transactions_mortgage_id_mortgages_id_fk": {
+          "name": "mortgage_transactions_mortgage_id_mortgages_id_fk",
+          "tableFrom": "mortgage_transactions",
+          "tableTo": "mortgages",
+          "columnsFrom": ["mortgage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mortgages": {
+      "name": "mortgages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "property_address": {
+          "name": "property_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lender": {
+          "name": "lender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_amount": {
+          "name": "original_amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outstanding_balance": {
+          "name": "outstanding_balance",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_value": {
+          "name": "property_value",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthly_payment": {
+          "name": "monthly_payment",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest_rate": {
+          "name": "interest_rate",
+          "type": "numeric(7, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_type": {
+          "name": "rate_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fixed_until": {
+          "name": "fixed_until",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "term_years": {
+          "name": "term_years",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overpayment_limit": {
+          "name": "overpayment_limit",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_joint": {
+          "name": "is_joint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mortgages_user_id_idx": {
+          "name": "mortgages_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mortgages_user_id_users_id_fk": {
+          "name": "mortgages_user_id_users_id_fk",
+          "tableFrom": "mortgages",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_links": {
+      "name": "partner_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addressee_id": {
+          "name": "addressee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "partner_link_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "partner_links_requester_id_unique": {
+          "name": "partner_links_requester_id_unique",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_links_addressee_id_unique": {
+          "name": "partner_links_addressee_id_unique",
+          "columns": [
+            {
+              "expression": "addressee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partner_links_requester_id_users_id_fk": {
+          "name": "partner_links_requester_id_users_id_fk",
+          "tableFrom": "partner_links",
+          "tableTo": "users",
+          "columnsFrom": ["requester_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "partner_links_addressee_id_users_id_fk": {
+          "name": "partner_links_addressee_id_users_id_fk",
+          "tableFrom": "partner_links",
+          "tableTo": "users",
+          "columnsFrom": ["addressee_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "partner_links_no_self_link_check": {
+          "name": "partner_links_no_self_link_check",
+          "value": "\"partner_links\".\"requester_id\" <> \"partner_links\".\"addressee_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.payslips": {
+      "name": "payslips",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gross": {
+          "name": "gross",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pension": {
+          "name": "pension",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "net": {
+          "name": "net",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bonus": {
+          "name": "bonus",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "document_storage_key": {
+          "name": "document_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_file_name": {
+          "name": "document_file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_size_bytes": {
+          "name": "document_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_uploaded_at": {
+          "name": "document_uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payslips_user_id_idx": {
+          "name": "payslips_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payslips_user_date_idx": {
+          "name": "payslips_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payslips_user_id_users_id_fk": {
+          "name": "payslips_user_id_users_id_fk",
+          "tableFrom": "payslips",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "payslips_document_fields_chk": {
+          "name": "payslips_document_fields_chk",
+          "value": "((\"payslips\".\"document_storage_key\" is null and \"payslips\".\"document_file_name\" is null and \"payslips\".\"document_size_bytes\" is null and \"payslips\".\"document_uploaded_at\" is null) or (\"payslips\".\"document_storage_key\" is not null and \"payslips\".\"document_file_name\" is not null and \"payslips\".\"document_size_bytes\" is not null and \"payslips\".\"document_uploaded_at\" is not null))"
+        },
+        "payslips_document_size_bytes_chk": {
+          "name": "payslips_document_size_bytes_chk",
+          "value": "\"payslips\".\"document_size_bytes\" is null or \"payslips\".\"document_size_bytes\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pension_pots": {
+      "name": "pension_pots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employee_monthly": {
+          "name": "employee_monthly",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employer_monthly": {
+          "name": "employer_monthly",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investment_strategy": {
+          "name": "investment_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pension_pots_user_id_idx": {
+          "name": "pension_pots_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pension_pots_user_id_users_id_fk": {
+          "name": "pension_pots_user_id_users_id_fk",
+          "tableFrom": "pension_pots",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pension_statement_import_rows": {
+      "name": "pension_statement_import_rows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "import_id": {
+          "name": "import_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_order": {
+          "name": "row_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_employer": {
+          "name": "is_employer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "confidence_label": {
+          "name": "confidence_label",
+          "type": "pension_import_confidence_label",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'low'"
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_derived": {
+          "name": "is_derived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "collision_warning": {
+          "name": "collision_warning",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_transaction_id": {
+          "name": "committed_transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pension_statement_import_rows_import_order_idx": {
+          "name": "pension_statement_import_rows_import_order_idx",
+          "columns": [
+            {
+              "expression": "import_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "row_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pension_statement_import_rows_import_deleted_idx": {
+          "name": "pension_statement_import_rows_import_deleted_idx",
+          "columns": [
+            {
+              "expression": "import_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pension_statement_import_rows_committed_txn_idx": {
+          "name": "pension_statement_import_rows_committed_txn_idx",
+          "columns": [
+            {
+              "expression": "committed_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pension_statement_import_rows_import_id_pension_statement_imports_id_fk": {
+          "name": "pension_statement_import_rows_import_id_pension_statement_imports_id_fk",
+          "tableFrom": "pension_statement_import_rows",
+          "tableTo": "pension_statement_imports",
+          "columnsFrom": ["import_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pension_statement_import_rows_committed_transaction_id_pension_transactions_id_fk": {
+          "name": "pension_statement_import_rows_committed_transaction_id_pension_transactions_id_fk",
+          "tableFrom": "pension_statement_import_rows",
+          "tableTo": "pension_transactions",
+          "columnsFrom": ["committed_transaction_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pension_statement_imports": {
+      "name": "pension_statement_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pot_id": {
+          "name": "pot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pension_import_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash_sha256": {
+          "name": "file_hash_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement_period_start": {
+          "name": "statement_period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_period_end": {
+          "name": "statement_period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language_hints": {
+          "name": "language_hints",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pension_statement_imports_user_status_idx": {
+          "name": "pension_statement_imports_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pension_statement_imports_pot_id_idx": {
+          "name": "pension_statement_imports_pot_id_idx",
+          "columns": [
+            {
+              "expression": "pot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pension_statement_imports_hash_idx": {
+          "name": "pension_statement_imports_hash_idx",
+          "columns": [
+            {
+              "expression": "file_hash_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pension_statement_imports_user_id_users_id_fk": {
+          "name": "pension_statement_imports_user_id_users_id_fk",
+          "tableFrom": "pension_statement_imports",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pension_statement_imports_pot_id_pension_pots_id_fk": {
+          "name": "pension_statement_imports_pot_id_pension_pots_id_fk",
+          "tableFrom": "pension_statement_imports",
+          "tableTo": "pension_pots",
+          "columnsFrom": ["pot_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pension_transactions": {
+      "name": "pension_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pot_id": {
+          "name": "pot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_employer": {
+          "name": "is_employer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_storage_key": {
+          "name": "document_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_file_name": {
+          "name": "document_file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_size_bytes": {
+          "name": "document_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_uploaded_at": {
+          "name": "document_uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pension_transactions_user_id_idx": {
+          "name": "pension_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pension_transactions_user_date_idx": {
+          "name": "pension_transactions_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pension_transactions_user_id_users_id_fk": {
+          "name": "pension_transactions_user_id_users_id_fk",
+          "tableFrom": "pension_transactions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pension_transactions_pot_id_pension_pots_id_fk": {
+          "name": "pension_transactions_pot_id_pension_pots_id_fk",
+          "tableFrom": "pension_transactions",
+          "tableTo": "pension_pots",
+          "columnsFrom": ["pot_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pension_transactions_document_fields_chk": {
+          "name": "pension_transactions_document_fields_chk",
+          "value": "((\"pension_transactions\".\"document_storage_key\" is null and \"pension_transactions\".\"document_file_name\" is null and \"pension_transactions\".\"document_size_bytes\" is null and \"pension_transactions\".\"document_uploaded_at\" is null) or (\"pension_transactions\".\"document_storage_key\" is not null and \"pension_transactions\".\"document_file_name\" is not null and \"pension_transactions\".\"document_size_bytes\" is not null and \"pension_transactions\".\"document_uploaded_at\" is not null))"
+        },
+        "pension_transactions_document_size_bytes_chk": {
+          "name": "pension_transactions_document_size_bytes_chk",
+          "value": "\"pension_transactions\".\"document_size_bytes\" is null or \"pension_transactions\".\"document_size_bytes\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.properties": {
+      "name": "properties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_type": {
+          "name": "property_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mortgage": {
+          "name": "mortgage",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mortgage_id": {
+          "name": "mortgage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_rent": {
+          "name": "monthly_rent",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_joint": {
+          "name": "is_joint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "properties_user_id_idx": {
+          "name": "properties_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_mortgage_id_idx": {
+          "name": "properties_mortgage_id_idx",
+          "columns": [
+            {
+              "expression": "mortgage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "properties_user_id_users_id_fk": {
+          "name": "properties_user_id_users_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.property_transactions": {
+      "name": "property_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest": {
+          "name": "interest",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal": {
+          "name": "principal",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "property_transactions_user_id_idx": {
+          "name": "property_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "property_transactions_user_date_idx": {
+          "name": "property_transactions_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "property_transactions_user_id_users_id_fk": {
+          "name": "property_transactions_user_id_users_id_fk",
+          "tableFrom": "property_transactions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "property_transactions_property_id_properties_id_fk": {
+          "name": "property_transactions_property_id_properties_id_fk",
+          "tableFrom": "property_transactions",
+          "tableTo": "properties",
+          "columnsFrom": ["property_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.savings_accounts": {
+      "name": "savings_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bank": {
+          "name": "bank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest_rate": {
+          "name": "interest_rate",
+          "type": "numeric(7, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bunq_account_id": {
+          "name": "bunq_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_joint": {
+          "name": "is_joint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "savings_accounts_user_id_idx": {
+          "name": "savings_accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "savings_accounts_user_bunq_account_id_unique": {
+          "name": "savings_accounts_user_bunq_account_id_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bunq_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "savings_accounts_user_id_users_id_fk": {
+          "name": "savings_accounts_user_id_users_id_fk",
+          "tableFrom": "savings_accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.savings_transactions": {
+      "name": "savings_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bunq_transaction_id": {
+          "name": "bunq_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "savings_transactions_user_id_idx": {
+          "name": "savings_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "savings_transactions_user_date_idx": {
+          "name": "savings_transactions_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "savings_transactions_user_bunq_transaction_id_unique": {
+          "name": "savings_transactions_user_bunq_transaction_id_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bunq_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "savings_transactions_user_id_users_id_fk": {
+          "name": "savings_transactions_user_id_users_id_fk",
+          "tableFrom": "savings_transactions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "savings_transactions_account_id_savings_accounts_id_fk": {
+          "name": "savings_transactions_account_id_savings_accounts_id_fk",
+          "tableFrom": "savings_transactions",
+          "tableTo": "savings_accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stock_exchanges": {
+      "name": "stock_exchanges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mic": {
+          "name": "mic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acronym": {
+          "name": "acronym",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stock_exchanges_mic_unique": {
+          "name": "stock_exchanges_mic_unique",
+          "nullsNotDistinct": false,
+          "columns": ["mic"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 35
+        },
+        "retirement_age": {
+          "name": "retirement_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 67
+        },
+        "base_currency": {
+          "name": "base_currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "number_format": {
+          "name": "number_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en-US'"
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_updated_at": {
+          "name": "password_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_age_range_check": {
+          "name": "users_age_range_check",
+          "value": "\"users\".\"age\" between 16 and 100"
+        },
+        "users_retirement_age_range_check": {
+          "name": "users_retirement_age_range_check",
+          "value": "\"users\".\"retirement_age\" between 17 and 80"
+        },
+        "users_retirement_after_age_check": {
+          "name": "users_retirement_after_age_check",
+          "value": "\"users\".\"retirement_age\" > \"users\".\"age\""
+        },
+        "users_number_format_check": {
+          "name": "users_number_format_check",
+          "value": "\"users\".\"number_format\" in ('en-US', 'de-DE')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.worker_heartbeats": {
+      "name": "worker_heartbeats",
+      "schema": "",
+      "columns": {
+        "worker_name": {
+          "name": "worker_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parser_healthy": {
+          "name": "parser_healthy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "parser_checked_at": {
+          "name": "parser_checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parser_error": {
+          "name": "parser_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.bunq_sync_status": {
+      "name": "bunq_sync_status",
+      "schema": "public",
+      "values": ["idle", "syncing", "error"]
+    },
+    "public.currency_code": {
+      "name": "currency_code",
+      "schema": "public",
+      "values": ["EUR", "GBP", "USD", "AUD", "NZD", "CAD", "CHF", "SGD"]
+    },
+    "public.partner_link_status": {
+      "name": "partner_link_status",
+      "schema": "public",
+      "values": ["pending", "accepted"]
+    },
+    "public.pension_import_confidence_label": {
+      "name": "pension_import_confidence_label",
+      "schema": "public",
+      "values": ["high", "medium", "low"]
+    },
+    "public.pension_import_status": {
+      "name": "pension_import_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "processing",
+        "ready_for_review",
+        "failed",
+        "committed",
+        "expired",
+        "cancelled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/backend/src/db/migrations/meta/_journal.json
+++ b/packages/backend/src/db/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1778768294138,
       "tag": "0016_cloudy_cargill",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1781269781667,
+      "tag": "0017_fancy_riptide",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/src/db/schema.ts
+++ b/packages/backend/src/db/schema.ts
@@ -40,6 +40,7 @@ export const pensionImportConfidenceLabelEnum = pgEnum('pension_import_confidenc
   'low',
 ]);
 export const bunqSyncStatusEnum = pgEnum('bunq_sync_status', ['idle', 'syncing', 'error']);
+export const partnerLinkStatusEnum = pgEnum('partner_link_status', ['pending', 'accepted']);
 
 const inlinePdfDocumentColumns = () => ({
   documentStorageKey: text('document_storage_key'),
@@ -131,6 +132,32 @@ export const sessions = pgTable(
   }),
 );
 
+// ── Partner Links ────────────────────────────────────────────────────────────
+
+export const partnerLinks = pgTable(
+  'partner_links',
+  {
+    id: serial('id').primaryKey(),
+    requesterId: integer('requester_id')
+      .references(() => users.id, { onDelete: 'cascade' })
+      .notNull(),
+    addresseeId: integer('addressee_id')
+      .references(() => users.id, { onDelete: 'cascade' })
+      .notNull(),
+    status: partnerLinkStatusEnum('status').notNull().default('pending'),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    respondedAt: timestamp('responded_at'),
+  },
+  (table) => ({
+    requesterUnique: uniqueIndex('partner_links_requester_id_unique').on(table.requesterId),
+    addresseeUnique: uniqueIndex('partner_links_addressee_id_unique').on(table.addresseeId),
+    noSelfLinkCheck: check(
+      'partner_links_no_self_link_check',
+      sql`${table.requesterId} <> ${table.addresseeId}`,
+    ),
+  }),
+);
+
 // ── Worker Heartbeats ───────────────────────────────────────────────────────
 
 export const workerHeartbeats = pgTable('worker_heartbeats', {
@@ -160,6 +187,7 @@ export const savingsAccounts = pgTable(
     color: text('color'),
     emoji: text('emoji'),
     bunqAccountId: text('bunq_account_id'),
+    isJoint: boolean('is_joint').notNull().default(false),
     archivedAt: timestamp('archived_at'),
   },
   (table) => ({
@@ -297,6 +325,7 @@ export const properties = pgTable(
     monthlyRent: numeric('monthly_rent', { precision: 19, scale: 2 }).notNull(),
     currency: currencyCodeEnum('currency').notNull(),
     emoji: text('emoji'),
+    isJoint: boolean('is_joint').notNull().default(false),
   },
   (table) => ({
     userIdx: index('properties_user_id_idx').on(table.userId),
@@ -491,6 +520,7 @@ export const mortgages = pgTable(
     startDate: text('start_date').notNull(),
     endDate: text('end_date').notNull(),
     overpaymentLimit: numeric('overpayment_limit', { precision: 19, scale: 2 }),
+    isJoint: boolean('is_joint').notNull().default(false),
     archivedAt: timestamp('archived_at'),
   },
   (table) => ({

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -17,6 +17,7 @@ import dashboard from './routes/dashboard';
 import currency from './routes/currency';
 import capabilities from './routes/capabilities';
 import settings from './routes/settings';
+import partner from './routes/partner';
 import bunq from './routes/bunq';
 import {
   getCoreReadinessReport,
@@ -62,6 +63,8 @@ app.use('/api/capabilities', requireAuth);
 app.use('/api/capabilities/*', requireAuth);
 app.use('/api/settings', requireAuth);
 app.use('/api/settings/*', requireAuth);
+app.use('/api/partner', requireAuth);
+app.use('/api/partner/*', requireAuth);
 app.use('/api/bunq/oauth/start', requireAuth);
 app.use('/api/bunq/oauth/callback', requireAuth);
 app.use('/api/bunq/connection', requireAuth);
@@ -81,6 +84,7 @@ app.route('/api/dashboard', dashboard);
 app.route('/api/currency', currency);
 app.route('/api/capabilities', capabilities);
 app.route('/api/settings', settings);
+app.route('/api/partner', partner);
 app.route('/api/bunq', bunq);
 
 startSessionCleanup();

--- a/packages/backend/src/lib/partner.ts
+++ b/packages/backend/src/lib/partner.ts
@@ -1,0 +1,43 @@
+import { and, eq, or, type SQL } from 'drizzle-orm';
+import type { PgColumn } from 'drizzle-orm/pg-core';
+import { db } from '../db/client';
+import { partnerLinks } from '../db/schema';
+
+export async function getAcceptedPartnerId(userId: number): Promise<number | null> {
+  const [link] = await db
+    .select({ requesterId: partnerLinks.requesterId, addresseeId: partnerLinks.addresseeId })
+    .from(partnerLinks)
+    .where(
+      and(
+        eq(partnerLinks.status, 'accepted'),
+        or(eq(partnerLinks.requesterId, userId), eq(partnerLinks.addresseeId, userId)),
+      ),
+    );
+  if (!link) return null;
+  return link.requesterId === userId ? link.addresseeId : link.requesterId;
+}
+
+type JointScopedTable = {
+  userId: PgColumn;
+  isJoint: PgColumn;
+};
+
+export function ownedOrJointPredicate(
+  table: JointScopedTable,
+  userId: number,
+  partnerId: number | null,
+): SQL {
+  const owned = eq(table.userId, userId);
+  if (partnerId === null) return owned;
+  const jointWithPartner = and(eq(table.userId, partnerId), eq(table.isJoint, true));
+  return or(owned, jointWithPartner) as SQL;
+}
+
+export async function assertJointAllowed(
+  userId: number,
+  isJoint: boolean | undefined,
+): Promise<string | null> {
+  if (!isJoint) return null;
+  const partnerId = await getAcceptedPartnerId(userId);
+  return partnerId === null ? 'No partner linked' : null;
+}

--- a/packages/backend/src/lib/savingsBalance.ts
+++ b/packages/backend/src/lib/savingsBalance.ts
@@ -1,4 +1,4 @@
-import { and, eq, sql } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { db } from '../db/client';
 import { savingsAccounts } from '../db/schema';
 import { parseNumber } from './requestValidation';
@@ -13,9 +13,11 @@ export function toSignedSavingsAmount(type: unknown, amount: unknown): number {
   return type === 'withdrawal' ? -absoluteAmount : absoluteAmount;
 }
 
+// Callers must verify the actor can access the account (owned or joint) before
+// invoking this; the update itself is intentionally not user-scoped so partner
+// transactions on joint accounts still adjust the balance.
 export async function updateSavingsAccountBalanceByDelta(
   accountId: number,
-  userId: number,
   delta: number,
 ): Promise<void> {
   if (delta === 0) return;
@@ -24,5 +26,5 @@ export async function updateSavingsAccountBalanceByDelta(
     .set({
       balance: sql`CAST(${savingsAccounts.balance} AS numeric) + ${delta}`,
     })
-    .where(and(eq(savingsAccounts.id, accountId), eq(savingsAccounts.userId, userId)));
+    .where(eq(savingsAccounts.id, accountId));
 }

--- a/packages/backend/src/routes/dashboard.ts
+++ b/packages/backend/src/routes/dashboard.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, getTableColumns, isNull } from 'drizzle-orm';
 import { db } from '../db/client';
 import {
   budgetTransactions,
@@ -20,10 +20,13 @@ import {
 import { getAuthUser } from '../lib/authUser';
 import { convertToBaseCurrency, FX_BASE_CURRENCY } from '../lib/currencyRateCache';
 import { getCurrentRatesToBaseCurrency } from '../lib/currencyRateSync';
+import { getAcceptedPartnerId, ownedOrJointPredicate } from '../lib/partner';
 
 const app = new Hono();
 const BASE_CURRENCY = FX_BASE_CURRENCY;
 const NET_WORTH_HISTORY_MONTHS = 7;
+// Joint assets count half for each partner so the two dashboards sum to reality.
+const JOINT_WEIGHT = 0.5;
 
 const toNumber = (value: unknown): number => {
   if (typeof value === 'number') return Number.isFinite(value) ? value : 0;
@@ -219,6 +222,126 @@ function resolveCurrency(
   return currencyById.get(id) ?? fallback;
 }
 
+// ── Joint-asset weighting ────────────────────────────────────────────────────
+// All net-worth/allocation formulas are linear in an asset's monetary fields,
+// so pre-scaling joint rows (and their transactions) by JOINT_WEIGHT halves
+// their contribution exactly without touching the compute functions.
+
+function buildJointIdSet(rows: ReadonlyArray<{ id: number; isJoint: boolean }>): Set<number> {
+  const ids = new Set<number>();
+  for (const row of rows) {
+    if (row.isJoint) ids.add(row.id);
+  }
+  return ids;
+}
+
+function weighJointSavingsAccounts(
+  rows: ReadonlyArray<typeof savingsAccounts.$inferSelect>,
+): HistoricalSavingsAccountRow[] {
+  return rows.map((row) =>
+    row.isJoint ? { ...row, balance: toNumber(row.balance) * JOINT_WEIGHT } : row,
+  );
+}
+
+function weighJointSavingsTransactions(
+  rows: ReadonlyArray<typeof savingsTransactions.$inferSelect>,
+  jointAccountIds: ReadonlySet<number>,
+): SavingsTransactionRow[] {
+  return rows.map((row) =>
+    jointAccountIds.has(row.accountId)
+      ? { ...row, amount: toNumber(row.amount) * JOINT_WEIGHT }
+      : row,
+  );
+}
+
+function weighJointProperties(
+  rows: ReadonlyArray<typeof properties.$inferSelect>,
+): Array<PropertyRow & { isJoint: boolean }> {
+  return rows.map((row) =>
+    row.isJoint
+      ? {
+          ...row,
+          purchasePrice: toNumber(row.purchasePrice) * JOINT_WEIGHT,
+          currentValue: toNumber(row.currentValue) * JOINT_WEIGHT,
+          mortgage: toNumber(row.mortgage) * JOINT_WEIGHT,
+        }
+      : row,
+  );
+}
+
+function weighJointPropertyTransactions(
+  rows: ReadonlyArray<typeof propertyTransactions.$inferSelect>,
+  jointPropertyIds: ReadonlySet<number>,
+): PropertyTransactionRow[] {
+  return rows.map((row) =>
+    jointPropertyIds.has(row.propertyId)
+      ? {
+          ...row,
+          amount: toNumber(row.amount) * JOINT_WEIGHT,
+          interest: row.interest == null ? null : toNumber(row.interest) * JOINT_WEIGHT,
+          principal: row.principal == null ? null : toNumber(row.principal) * JOINT_WEIGHT,
+        }
+      : row,
+  );
+}
+
+function weighJointMortgages(
+  rows: ReadonlyArray<typeof mortgages.$inferSelect>,
+): Array<MortgageRow & { isJoint: boolean }> {
+  return rows.map((row) =>
+    row.isJoint
+      ? { ...row, outstandingBalance: toNumber(row.outstandingBalance) * JOINT_WEIGHT }
+      : row,
+  );
+}
+
+type JointScopedSourceRows = {
+  savings: Array<typeof savingsAccounts.$inferSelect>;
+  savingsTransactions: Array<typeof savingsTransactions.$inferSelect>;
+  properties: Array<typeof properties.$inferSelect>;
+  propertyTransactions: Array<typeof propertyTransactions.$inferSelect>;
+  mortgages: Array<typeof mortgages.$inferSelect>;
+};
+
+async function loadJointScopedRows(userId: number): Promise<JointScopedSourceRows> {
+  const partnerId = await getAcceptedPartnerId(userId);
+  const savingsAccess = ownedOrJointPredicate(savingsAccounts, userId, partnerId);
+  const propertyAccess = ownedOrJointPredicate(properties, userId, partnerId);
+  const mortgageAccess = ownedOrJointPredicate(mortgages, userId, partnerId);
+
+  const [savings, savingsTxns, propertyRows, propertyTxns, mortgageRows] = await Promise.all([
+    safeLoad('savings accounts', db.select().from(savingsAccounts).where(savingsAccess), []),
+    safeLoad(
+      'savings transactions',
+      db
+        .select(getTableColumns(savingsTransactions))
+        .from(savingsTransactions)
+        .innerJoin(savingsAccounts, eq(savingsTransactions.accountId, savingsAccounts.id))
+        .where(savingsAccess),
+      [],
+    ),
+    safeLoad('properties', db.select().from(properties).where(propertyAccess), []),
+    safeLoad(
+      'property transactions',
+      db
+        .select(getTableColumns(propertyTransactions))
+        .from(propertyTransactions)
+        .innerJoin(properties, eq(propertyTransactions.propertyId, properties.id))
+        .where(propertyAccess),
+      [],
+    ),
+    safeLoad('mortgages', db.select().from(mortgages).where(mortgageAccess), []),
+  ]);
+
+  return {
+    savings,
+    savingsTransactions: savingsTxns,
+    properties: propertyRows,
+    propertyTransactions: propertyTxns,
+    mortgages: mortgageRows,
+  };
+}
+
 function buildDatedSavingsTransactions(
   transactions: readonly SavingsTransactionRow[],
 ): DatedSavingsTransaction[] {
@@ -401,48 +524,32 @@ export function computeDerivedAllocations(
 }
 
 async function buildDerivedAllocations(userId: number): Promise<DerivedAllocationSummary> {
-  const [
-    rates,
-    userSavings,
-    userHoldings,
-    userHoldingTxns,
-    userProperties,
-    userPensions,
-    userMortgages,
-    userDebts,
-  ] = await Promise.all([
-    getRatesToBaseCurrency(),
-    db
-      .select()
-      .from(savingsAccounts)
-      .where(and(eq(savingsAccounts.userId, userId), isNull(savingsAccounts.archivedAt))),
-    db
-      .select()
-      .from(holdings)
-      .where(and(eq(holdings.userId, userId), isNull(holdings.archivedAt))),
-    db.select().from(holdingTransactions).where(eq(holdingTransactions.userId, userId)),
-    db.select().from(properties).where(eq(properties.userId, userId)),
-    db
-      .select()
-      .from(pensionPots)
-      .where(and(eq(pensionPots.userId, userId), isNull(pensionPots.archivedAt))),
-    db
-      .select()
-      .from(mortgages)
-      .where(and(eq(mortgages.userId, userId), isNull(mortgages.archivedAt))),
-    db
-      .select()
-      .from(debts)
-      .where(and(eq(debts.userId, userId), isNull(debts.archivedAt))),
-  ]);
+  const [rates, jointScoped, userHoldings, userHoldingTxns, userPensions, userDebts] =
+    await Promise.all([
+      getRatesToBaseCurrency(),
+      loadJointScopedRows(userId),
+      db
+        .select()
+        .from(holdings)
+        .where(and(eq(holdings.userId, userId), isNull(holdings.archivedAt))),
+      db.select().from(holdingTransactions).where(eq(holdingTransactions.userId, userId)),
+      db
+        .select()
+        .from(pensionPots)
+        .where(and(eq(pensionPots.userId, userId), isNull(pensionPots.archivedAt))),
+      db
+        .select()
+        .from(debts)
+        .where(and(eq(debts.userId, userId), isNull(debts.archivedAt))),
+    ]);
   return computeDerivedAllocations(
     rates,
-    userSavings,
+    weighJointSavingsAccounts(jointScoped.savings.filter((row) => !row.archivedAt)),
     userHoldings,
     userHoldingTxns,
-    userProperties,
+    weighJointProperties(jointScoped.properties),
     userPensions,
-    userMortgages,
+    weighJointMortgages(jointScoped.mortgages.filter((row) => !row.archivedAt)),
     userDebts,
   );
 }
@@ -628,38 +735,19 @@ async function safeLoad<T>(label: string, query: Promise<T>, fallback: T): Promi
 async function loadNetWorthSourceData(userId: number): Promise<NetWorthSourceData> {
   const rates = await getRatesToBaseCurrency();
   const [
-    savings,
-    savingsTransactionsData,
+    jointScoped,
     holdingsData,
     holdingTransactionsData,
-    propertiesData,
-    propertyTransactionsData,
     pensions,
     pensionTransactionsData,
-    mortgagesData,
     debtsData,
     debtPaymentsData,
   ] = await Promise.all([
-    safeLoad(
-      'savings accounts',
-      db.select().from(savingsAccounts).where(eq(savingsAccounts.userId, userId)),
-      [],
-    ),
-    safeLoad(
-      'savings transactions',
-      db.select().from(savingsTransactions).where(eq(savingsTransactions.userId, userId)),
-      [],
-    ),
+    loadJointScopedRows(userId),
     safeLoad('holdings', db.select().from(holdings).where(eq(holdings.userId, userId)), []),
     safeLoad(
       'holding transactions',
       db.select().from(holdingTransactions).where(eq(holdingTransactions.userId, userId)),
-      [],
-    ),
-    safeLoad('properties', db.select().from(properties).where(eq(properties.userId, userId)), []),
-    safeLoad(
-      'property transactions',
-      db.select().from(propertyTransactions).where(eq(propertyTransactions.userId, userId)),
       [],
     ),
     safeLoad(
@@ -672,7 +760,6 @@ async function loadNetWorthSourceData(userId: number): Promise<NetWorthSourceDat
       db.select().from(pensionTransactions).where(eq(pensionTransactions.userId, userId)),
       [],
     ),
-    safeLoad('mortgages', db.select().from(mortgages).where(eq(mortgages.userId, userId)), []),
     safeLoad('debts', db.select().from(debts).where(eq(debts.userId, userId)), []),
     safeLoad(
       'debt payments',
@@ -683,15 +770,21 @@ async function loadNetWorthSourceData(userId: number): Promise<NetWorthSourceDat
 
   return {
     rates,
-    savings,
-    savingsTransactions: savingsTransactionsData,
+    savings: weighJointSavingsAccounts(jointScoped.savings),
+    savingsTransactions: weighJointSavingsTransactions(
+      jointScoped.savingsTransactions,
+      buildJointIdSet(jointScoped.savings),
+    ),
     holdings: holdingsData,
     holdingTransactions: holdingTransactionsData,
-    properties: propertiesData,
-    propertyTransactions: propertyTransactionsData,
+    properties: weighJointProperties(jointScoped.properties),
+    propertyTransactions: weighJointPropertyTransactions(
+      jointScoped.propertyTransactions,
+      buildJointIdSet(jointScoped.properties),
+    ),
     pensions,
     pensionTransactions: pensionTransactionsData,
-    mortgages: mortgagesData,
+    mortgages: weighJointMortgages(jointScoped.mortgages),
     debts: debtsData,
     debtPayments: debtPaymentsData,
   };
@@ -860,8 +953,30 @@ type DebtActivityRow = {
   note?: string | null;
 };
 
-function mapSavingsTxn(row: SavingsActivityRow, currencyByAccountId: ReadonlyMap<number, string>) {
-  const currency = resolveCurrency(currencyByAccountId, row.accountId);
+type ParentAssetInfo = { currency: string; isJoint: boolean };
+
+function buildParentInfoById(
+  rows: ReadonlyArray<{ id: number; currency: string; isJoint: boolean }>,
+): Map<number, ParentAssetInfo> {
+  const infos = new Map<number, ParentAssetInfo>();
+  for (const row of rows) {
+    infos.set(row.id, { currency: row.currency, isJoint: row.isJoint });
+  }
+  return infos;
+}
+
+function resolveParentInfo(
+  infoById: ReadonlyMap<number, ParentAssetInfo>,
+  id: number,
+): ParentAssetInfo {
+  return infoById.get(id) ?? { currency: BASE_CURRENCY, isJoint: false };
+}
+
+function mapSavingsTxn(
+  row: SavingsActivityRow,
+  infoByAccountId: ReadonlyMap<number, ParentAssetInfo>,
+) {
+  const { currency, isJoint } = resolveParentInfo(infoByAccountId, row.accountId);
   if (row.type === 'interest') {
     return {
       name: row.note || 'Savings interest',
@@ -870,6 +985,7 @@ function mapSavingsTxn(row: SavingsActivityRow, currencyByAccountId: ReadonlyMap
       date: row.date,
       category: 'Savings',
       currency,
+      isJoint,
     };
   }
   const isDeposit = row.type === 'deposit';
@@ -880,6 +996,7 @@ function mapSavingsTxn(row: SavingsActivityRow, currencyByAccountId: ReadonlyMap
     date: row.date,
     category: 'Savings',
     currency,
+    isJoint,
   };
 }
 
@@ -893,6 +1010,7 @@ function mapHoldingTxn(row: HoldingActivityRow, currencyByHoldingId: ReadonlyMap
       date: row.date,
       category: 'Investment',
       currency,
+      isJoint: false,
     };
   }
   const gross = toNumber(row.shares) * toNumber(row.price);
@@ -904,14 +1022,15 @@ function mapHoldingTxn(row: HoldingActivityRow, currencyByHoldingId: ReadonlyMap
     date: row.date,
     category: 'Investment',
     currency,
+    isJoint: false,
   };
 }
 
 function mapPropertyTxn(
   row: PropertyActivityRow,
-  currencyByPropertyId: ReadonlyMap<number, string>,
+  infoByPropertyId: ReadonlyMap<number, ParentAssetInfo>,
 ) {
-  const currency = resolveCurrency(currencyByPropertyId, row.propertyId);
+  const { currency, isJoint } = resolveParentInfo(infoByPropertyId, row.propertyId);
   const isIncome = row.type === 'rent_income';
   return {
     name: row.note || (isIncome ? 'Rent income' : 'Property expense'),
@@ -920,6 +1039,7 @@ function mapPropertyTxn(
     date: row.date,
     category: 'Property',
     currency,
+    isJoint,
   };
 }
 
@@ -931,6 +1051,7 @@ function mapPayslipActivity(row: PayslipActivityRow) {
     date: row.date,
     category: 'Salary',
     currency: row.currency,
+    isJoint: false,
   };
 }
 
@@ -942,20 +1063,23 @@ function mapBudgetActivity(row: BudgetActivityRow) {
     date: row.date,
     category: 'Budget',
     currency: BASE_CURRENCY,
+    isJoint: false,
   };
 }
 
 function mapMortgageTxn(
   row: MortgageActivityRow,
-  mortgageCurrencyById: ReadonlyMap<number, string>,
+  infoByMortgageId: ReadonlyMap<number, ParentAssetInfo>,
 ) {
+  const { currency, isJoint } = resolveParentInfo(infoByMortgageId, row.mortgageId);
   return {
     name: row.note || 'Mortgage repayment',
     type: 'expense' as const,
     amount: -Math.abs(toNumber(row.amount)),
     date: row.date,
     category: 'Mortgage',
-    currency: resolveCurrency(mortgageCurrencyById, row.mortgageId),
+    currency,
+    isJoint,
   };
 }
 
@@ -967,6 +1091,7 @@ function mapDebtPayment(row: DebtActivityRow, debtCurrencyById: ReadonlyMap<numb
     date: row.date,
     category: 'Debt',
     currency: resolveCurrency(debtCurrencyById, row.debtId),
+    isJoint: false,
   };
 }
 
@@ -987,6 +1112,7 @@ function mapPensionTxn(
       date: row.date,
       category: 'Pension',
       currency,
+      isJoint: false,
     };
   }
 
@@ -1000,6 +1126,7 @@ function mapPensionTxn(
       date: row.date,
       category: 'Pension',
       currency,
+      isJoint: false,
     };
   }
 
@@ -1010,6 +1137,7 @@ function mapPensionTxn(
     date: row.date,
     category: 'Pension',
     currency,
+    isJoint: false,
   };
 }
 
@@ -1022,51 +1150,108 @@ export function buildActivityList(
   debtRows: readonly DebtActivityRow[],
   pensionRows: readonly PensionActivityRow[],
   propertyRows: readonly PropertyActivityRow[],
-  savingsCurrencyByAccountId: ReadonlyMap<number, string>,
+  savingsInfoByAccountId: ReadonlyMap<number, ParentAssetInfo>,
   holdingCurrencyById: ReadonlyMap<number, string>,
-  mortgageCurrencyById: ReadonlyMap<number, string>,
+  mortgageInfoById: ReadonlyMap<number, ParentAssetInfo>,
   debtCurrencyById: ReadonlyMap<number, string>,
   pensionCurrencyByPotId: ReadonlyMap<number, string>,
-  propertyCurrencyById: ReadonlyMap<number, string>,
+  propertyInfoById: ReadonlyMap<number, ParentAssetInfo>,
 ) {
   return [
     ...payslipRows.map(mapPayslipActivity),
     ...budgetRows.map(mapBudgetActivity),
-    ...savingsRows.map((row) => mapSavingsTxn(row, savingsCurrencyByAccountId)),
+    ...savingsRows.map((row) => mapSavingsTxn(row, savingsInfoByAccountId)),
     ...holdingRows.map((row) => mapHoldingTxn(row, holdingCurrencyById)),
     ...mortgageRows
       .filter((row) => row.type === 'repayment')
-      .map((row) => mapMortgageTxn(row, mortgageCurrencyById)),
+      .map((row) => mapMortgageTxn(row, mortgageInfoById)),
     ...debtRows.map((row) => mapDebtPayment(row, debtCurrencyById)),
     ...pensionRows.map((row) => mapPensionTxn(row, pensionCurrencyByPotId)),
     ...propertyRows
       .filter((row) => row.type === 'rent_income' || row.type === 'expense')
-      .map((row) => mapPropertyTxn(row, propertyCurrencyById)),
+      .map((row) => mapPropertyTxn(row, propertyInfoById)),
   ]
     .sort((a, b) => b.date.localeCompare(a.date))
     .map((row, index) => ({ id: index + 1, ...row }));
 }
 
+type JointScopedActivityRows = {
+  savingsTxns: SavingsActivityRow[];
+  savingsParents: Array<{ id: number; currency: string; isJoint: boolean }>;
+  mortgageTxns: MortgageActivityRow[];
+  mortgageParents: Array<{ id: number; currency: string; isJoint: boolean }>;
+  propertyTxns: PropertyActivityRow[];
+  propertyParents: Array<{ id: number; currency: string; isJoint: boolean }>;
+};
+
+async function loadJointScopedActivityRows(userId: number): Promise<JointScopedActivityRows> {
+  const partnerId = await getAcceptedPartnerId(userId);
+  const savingsAccess = ownedOrJointPredicate(savingsAccounts, userId, partnerId);
+  const mortgageAccess = ownedOrJointPredicate(mortgages, userId, partnerId);
+  const propertyAccess = ownedOrJointPredicate(properties, userId, partnerId);
+
+  const [
+    savingsTxns,
+    savingsParents,
+    mortgageTxns,
+    mortgageParents,
+    propertyTxns,
+    propertyParents,
+  ] = await Promise.all([
+    db
+      .select(getTableColumns(savingsTransactions))
+      .from(savingsTransactions)
+      .innerJoin(savingsAccounts, eq(savingsTransactions.accountId, savingsAccounts.id))
+      .where(savingsAccess),
+    db
+      .select({
+        id: savingsAccounts.id,
+        currency: savingsAccounts.currency,
+        isJoint: savingsAccounts.isJoint,
+      })
+      .from(savingsAccounts)
+      .where(savingsAccess),
+    db
+      .select(getTableColumns(mortgageTransactions))
+      .from(mortgageTransactions)
+      .innerJoin(mortgages, eq(mortgageTransactions.mortgageId, mortgages.id))
+      .where(mortgageAccess),
+    db
+      .select({ id: mortgages.id, currency: mortgages.currency, isJoint: mortgages.isJoint })
+      .from(mortgages)
+      .where(mortgageAccess),
+    db
+      .select(getTableColumns(propertyTransactions))
+      .from(propertyTransactions)
+      .innerJoin(properties, eq(propertyTransactions.propertyId, properties.id))
+      .where(propertyAccess),
+    db
+      .select({ id: properties.id, currency: properties.currency, isJoint: properties.isJoint })
+      .from(properties)
+      .where(propertyAccess),
+  ]);
+
+  return {
+    savingsTxns,
+    savingsParents,
+    mortgageTxns,
+    mortgageParents,
+    propertyTxns,
+    propertyParents,
+  };
+}
+
 app.get('/transactions', async (c) => {
   const user = getAuthUser(c);
-  const [p, b, s, sa, h, ho, m, mo, d, doRows, pe, po, pr, ps] = await Promise.all([
+  const [jointScoped, p, b, h, ho, d, doRows, pe, po] = await Promise.all([
+    loadJointScopedActivityRows(user.id),
     db.select().from(payslips).where(eq(payslips.userId, user.id)),
     db.select().from(budgetTransactions).where(eq(budgetTransactions.userId, user.id)),
-    db.select().from(savingsTransactions).where(eq(savingsTransactions.userId, user.id)),
-    db
-      .select({ id: savingsAccounts.id, currency: savingsAccounts.currency })
-      .from(savingsAccounts)
-      .where(eq(savingsAccounts.userId, user.id)),
     db.select().from(holdingTransactions).where(eq(holdingTransactions.userId, user.id)),
     db
       .select({ id: holdings.id, currency: holdings.currency })
       .from(holdings)
       .where(eq(holdings.userId, user.id)),
-    db.select().from(mortgageTransactions).where(eq(mortgageTransactions.userId, user.id)),
-    db
-      .select({ id: mortgages.id, currency: mortgages.currency })
-      .from(mortgages)
-      .where(eq(mortgages.userId, user.id)),
     db.select().from(debtPayments).where(eq(debtPayments.userId, user.id)),
     db
       .select({ id: debts.id, currency: debts.currency })
@@ -1077,28 +1262,23 @@ app.get('/transactions', async (c) => {
       .select({ id: pensionPots.id, currency: pensionPots.currency })
       .from(pensionPots)
       .where(eq(pensionPots.userId, user.id)),
-    db.select().from(propertyTransactions).where(eq(propertyTransactions.userId, user.id)),
-    db
-      .select({ id: properties.id, currency: properties.currency })
-      .from(properties)
-      .where(eq(properties.userId, user.id)),
   ]);
   return c.json({
     data: buildActivityList(
       p,
       b,
-      s,
+      jointScoped.savingsTxns,
       h,
-      m,
+      jointScoped.mortgageTxns,
       d,
       pe,
-      pr,
-      buildCurrencyById(sa),
+      jointScoped.propertyTxns,
+      buildParentInfoById(jointScoped.savingsParents),
       buildCurrencyById(ho),
-      buildCurrencyById(mo),
+      buildParentInfoById(jointScoped.mortgageParents),
       buildCurrencyById(doRows),
       buildCurrencyById(po),
-      buildCurrencyById(ps),
+      buildParentInfoById(jointScoped.propertyParents),
     ),
   });
 });

--- a/packages/backend/src/routes/investments.ts
+++ b/packages/backend/src/routes/investments.ts
@@ -20,15 +20,17 @@ import {
   propertyTransactions,
   stockExchanges,
 } from '../db/schema';
-import { and, asc, eq, gte, inArray, isNull, lte } from 'drizzle-orm';
+import { and, asc, eq, getTableColumns, gte, inArray, isNull, lte } from 'drizzle-orm';
 import { getAuthUser } from '../lib/authUser';
 import { HTTP_STATUS } from '../constants/http';
 import { lookupTicker } from '../lib/marketData';
 import { syncHoldingPricesForUser, upsertHoldingPriceSnapshot } from '../lib/holdingPriceSync';
+import { assertJointAllowed, getAcceptedPartnerId, ownedOrJointPredicate } from '../lib/partner';
 import {
   err,
   isRecord,
   ok,
+  parseBooleanField,
   parseCurrencyField,
   parseDateField,
   parseDateString,
@@ -79,6 +81,7 @@ const PROPERTY_FIELDS = [
   'monthlyRent',
   'currency',
   'emoji',
+  'isJoint',
 ] as const;
 const PROPERTY_TRANSACTION_FIELDS = [
   'propertyId',
@@ -198,6 +201,7 @@ type PropertyPayload = {
   monthlyRent: number;
   currency: CurrencyCode;
   emoji: string | null;
+  isJoint: boolean;
 };
 
 type PropertyTransactionPayload = {
@@ -210,7 +214,10 @@ type PropertyTransactionPayload = {
   note: string | null;
 };
 
-type PropertyCreateRequiredPayload = Omit<PropertyPayload, 'mortgage' | 'mortgageId' | 'emoji'>;
+type PropertyCreateRequiredPayload = Omit<
+  PropertyPayload,
+  'mortgage' | 'mortgageId' | 'emoji' | 'isJoint'
+>;
 
 function parseNormalizedDecimalField(
   value: unknown,
@@ -312,6 +319,8 @@ const propertyParsers: FieldParsers<PropertyPayload> = {
     parseNormalizedDecimalField(value, 'Monthly rent must be zero or greater', 0),
   currency: parseCurrencyField,
   emoji: (value) => parseOptionalTextField(value, 'Emoji must be a string'),
+  isJoint: (value) =>
+    value === undefined ? ok(false) : parseBooleanField(value, 'isJoint must be a boolean'),
 };
 
 const propertyCreateRequiredParsers: FieldParsers<PropertyCreateRequiredPayload> = {
@@ -404,12 +413,15 @@ function parsePropertyCreate(body: unknown): ParseResult<PropertyPayload> {
   if (!mortgageId.ok) return mortgageId;
   const emoji = propertyParsers.emoji(body.emoji);
   if (!emoji.ok) return emoji;
+  const isJoint = propertyParsers.isJoint(body.isJoint);
+  if (!isJoint.ok) return isJoint;
 
   return ok({
     ...required.value,
     mortgage: mortgage.value,
     mortgageId: mortgageId.value,
     emoji: emoji.value,
+    isJoint: isJoint.value,
   });
 }
 
@@ -621,6 +633,7 @@ function toPropertyInsertValues(
     monthlyRent: payload.monthlyRent.toString(),
     currency: payload.currency,
     emoji: payload.emoji,
+    isJoint: payload.isJoint,
   };
 }
 
@@ -637,6 +650,7 @@ function toPropertyUpdateValues(
     monthlyRent: payload.monthlyRent?.toString(),
     currency: payload.currency,
     emoji: payload.emoji,
+    isJoint: payload.isJoint,
   };
 }
 
@@ -793,20 +807,30 @@ async function getOwnedHoldingTransaction(userId: number, transactionId: number)
   return transaction ?? null;
 }
 
-async function getOwnedProperty(userId: number, propertyId: number) {
+async function getAccessibleProperty(userId: number, partnerId: number | null, propertyId: number) {
   const [property] = await db
     .select()
     .from(properties)
-    .where(and(eq(properties.id, propertyId), eq(properties.userId, userId)));
+    .where(
+      and(eq(properties.id, propertyId), ownedOrJointPredicate(properties, userId, partnerId)),
+    );
   return property ?? null;
 }
 
-async function getOwnedPropertyTransaction(userId: number, transactionId: number) {
+async function getAccessiblePropertyTransaction(
+  userId: number,
+  partnerId: number | null,
+  transactionId: number,
+) {
   const [transaction] = await db
-    .select()
+    .select(getTableColumns(propertyTransactions))
     .from(propertyTransactions)
+    .innerJoin(properties, eq(propertyTransactions.propertyId, properties.id))
     .where(
-      and(eq(propertyTransactions.id, transactionId), eq(propertyTransactions.userId, userId)),
+      and(
+        eq(propertyTransactions.id, transactionId),
+        ownedOrJointPredicate(properties, userId, partnerId),
+      ),
     );
   return transaction ?? null;
 }
@@ -836,32 +860,40 @@ async function readPropertyPatchPayload(
   return body;
 }
 
-async function getOwnedMortgageForPropertyLink(userId: number, mortgageId: number) {
+async function getAccessibleMortgageForPropertyLink(
+  userId: number,
+  partnerId: number | null,
+  mortgageId: number,
+) {
   const [mortgage] = await db
     .select({
       id: mortgages.id,
       outstandingBalance: mortgages.outstandingBalance,
+      isJoint: mortgages.isJoint,
     })
     .from(mortgages)
-    .where(and(eq(mortgages.id, mortgageId), eq(mortgages.userId, userId)));
+    .where(and(eq(mortgages.id, mortgageId), ownedOrJointPredicate(mortgages, userId, partnerId)));
   return mortgage ?? null;
 }
 
+// The mortgage id has already been access-checked, so the linked-property
+// search is by mortgageId alone (the property may belong to the partner).
 async function getPropertyLinkedToMortgage(params: {
-  userId: number;
   mortgageId: number;
   excludePropertyId?: number;
 }) {
   const linked = await db
     .select({ id: properties.id })
     .from(properties)
-    .where(and(eq(properties.userId, params.userId), eq(properties.mortgageId, params.mortgageId)));
+    .where(eq(properties.mortgageId, params.mortgageId));
 
   return linked.find((property) => property.id !== params.excludePropertyId) ?? null;
 }
 
+// Mortgage id comes from an access-checked property row, so the update is by
+// id only. Jointness propagates to keep the linked pair consistent for the
+// 50% dashboard weighting.
 async function syncMortgageSnapshotFromProperty(params: {
-  userId: number;
   mortgageId: number | null;
   property: typeof properties.$inferSelect;
 }): Promise<void> {
@@ -873,12 +905,14 @@ async function syncMortgageSnapshotFromProperty(params: {
       propertyAddress: params.property.address,
       currency: params.property.currency,
       propertyValue: params.property.currentValue,
+      isJoint: params.property.isJoint,
     })
-    .where(and(eq(mortgages.id, params.mortgageId), eq(mortgages.userId, params.userId)));
+    .where(eq(mortgages.id, params.mortgageId));
 }
 
 async function resolvePropertyMortgagePatch(params: {
   userId: number;
+  partnerId: number | null;
   propertyId: number;
   existing: typeof properties.$inferSelect;
   patch: Partial<PropertyPayload>;
@@ -902,11 +936,14 @@ async function resolvePropertyMortgagePatch(params: {
     };
   }
 
-  const mortgage = await getOwnedMortgageForPropertyLink(params.userId, nextMortgageId);
+  const mortgage = await getAccessibleMortgageForPropertyLink(
+    params.userId,
+    params.partnerId,
+    nextMortgageId,
+  );
   if (!mortgage) return { ok: false, error: 'Mortgage not found', status: HTTP_STATUS.NOT_FOUND };
 
   const linkedProperty = await getPropertyLinkedToMortgage({
-    userId: params.userId,
     mortgageId: nextMortgageId,
     excludePropertyId: params.propertyId,
   });
@@ -1256,7 +1293,11 @@ app.delete('/holding-transactions/:id', async (c) => {
 
 app.get('/properties', async (c) => {
   const user = getAuthUser(c);
-  const data = await db.select().from(properties).where(eq(properties.userId, user.id));
+  const partnerId = await getAcceptedPartnerId(user.id);
+  const data = await db
+    .select()
+    .from(properties)
+    .where(ownedOrJointPredicate(properties, user.id, partnerId));
   return c.json({ data });
 });
 
@@ -1264,10 +1305,8 @@ app.get('/properties/:id', async (c) => {
   const user = getAuthUser(c);
   const id = parseId(c.req.param('id'));
   if (id === null) return c.json({ error: 'Invalid property id' }, HTTP_STATUS.BAD_REQUEST);
-  const [data] = await db
-    .select()
-    .from(properties)
-    .where(and(eq(properties.id, id), eq(properties.userId, user.id)));
+  const partnerId = await getAcceptedPartnerId(user.id);
+  const data = await getAccessibleProperty(user.id, partnerId, id);
   if (!data) return c.json({ error: 'Property not found' }, HTTP_STATUS.NOT_FOUND);
   return c.json({ data });
 });
@@ -1280,13 +1319,18 @@ app.post('/properties', async (c) => {
   const body = parsePropertyCreate(rawBody.value);
   if (!body.ok) return c.json({ error: body.error }, HTTP_STATUS.BAD_REQUEST);
 
+  const partnerId = await getAcceptedPartnerId(user.id);
   let mortgageBalance = body.value.mortgage;
+  let isJoint = body.value.isJoint;
   if (body.value.mortgageId !== null) {
-    const mortgage = await getOwnedMortgageForPropertyLink(user.id, body.value.mortgageId);
+    const mortgage = await getAccessibleMortgageForPropertyLink(
+      user.id,
+      partnerId,
+      body.value.mortgageId,
+    );
     if (!mortgage) return c.json({ error: 'Mortgage not found' }, HTTP_STATUS.NOT_FOUND);
 
     const linkedProperty = await getPropertyLinkedToMortgage({
-      userId: user.id,
       mortgageId: body.value.mortgageId,
     });
     if (linkedProperty) {
@@ -1294,11 +1338,17 @@ app.post('/properties', async (c) => {
     }
 
     mortgageBalance = toNormalizedDecimal(mortgage.outstandingBalance) ?? 0;
+    // A property linked to a joint mortgage is joint too (and vice versa).
+    isJoint = isJoint || mortgage.isJoint;
   }
+
+  const jointError = await assertJointAllowed(user.id, isJoint);
+  if (jointError) return c.json({ error: jointError }, HTTP_STATUS.BAD_REQUEST);
 
   const propertyPayload = {
     ...body.value,
     mortgage: mortgageBalance,
+    isJoint,
   };
 
   const [data] = await db
@@ -1307,7 +1357,6 @@ app.post('/properties', async (c) => {
     .returning();
 
   await syncMortgageSnapshotFromProperty({
-    userId: user.id,
     mortgageId: data.mortgageId,
     property: data,
   });
@@ -1319,13 +1368,19 @@ app.patch('/properties/:id', async (c) => {
   const id = parseId(c.req.param('id'));
   if (id === null) return c.json({ error: 'Invalid property id' }, HTTP_STATUS.BAD_REQUEST);
 
-  const existing = await getOwnedProperty(user.id, id);
+  const partnerId = await getAcceptedPartnerId(user.id);
+  const existing = await getAccessibleProperty(user.id, partnerId, id);
   if (!existing) return c.json({ error: 'Property not found' }, HTTP_STATUS.NOT_FOUND);
 
   const body = await readPropertyPatchPayload(c.req);
   if (!body.ok) return c.json({ error: body.error }, body.status);
+
+  const jointError = await assertJointAllowed(user.id, body.value.isJoint);
+  if (jointError) return c.json({ error: jointError }, HTTP_STATUS.BAD_REQUEST);
+
   const mortgagePatch = await resolvePropertyMortgagePatch({
     userId: user.id,
+    partnerId,
     propertyId: id,
     existing,
     patch: body.value,
@@ -1340,11 +1395,10 @@ app.patch('/properties/:id', async (c) => {
   const [data] = await db
     .update(properties)
     .set(toPropertyUpdateValues(updates))
-    .where(and(eq(properties.id, id), eq(properties.userId, user.id)))
+    .where(eq(properties.id, id))
     .returning();
 
   await syncMortgageSnapshotFromProperty({
-    userId: user.id,
     mortgageId: data.mortgageId,
     property: data,
   });
@@ -1355,9 +1409,10 @@ app.delete('/properties/:id', async (c) => {
   const user = getAuthUser(c);
   const id = parseId(c.req.param('id'));
   if (id === null) return c.json({ error: 'Invalid property id' }, HTTP_STATUS.BAD_REQUEST);
+  const partnerId = await getAcceptedPartnerId(user.id);
   const [data] = await db
     .delete(properties)
-    .where(and(eq(properties.id, id), eq(properties.userId, user.id)))
+    .where(and(eq(properties.id, id), ownedOrJointPredicate(properties, user.id, partnerId)))
     .returning();
   if (!data) return c.json({ error: 'Property not found' }, HTTP_STATUS.NOT_FOUND);
   return c.json({ data });
@@ -1367,26 +1422,25 @@ app.delete('/properties/:id', async (c) => {
 
 app.get('/property-transactions', async (c) => {
   const user = getAuthUser(c);
+  const partnerId = await getAcceptedPartnerId(user.id);
   const propertyId = c.req.query('propertyId');
   if (propertyId) {
     const parsedPropertyId = parseId(propertyId);
     if (parsedPropertyId === null)
       return c.json({ error: 'Invalid property id' }, HTTP_STATUS.BAD_REQUEST);
+    const property = await getAccessibleProperty(user.id, partnerId, parsedPropertyId);
+    if (!property) return c.json({ error: 'Property not found' }, HTTP_STATUS.NOT_FOUND);
     const data = await db
       .select()
       .from(propertyTransactions)
-      .where(
-        and(
-          eq(propertyTransactions.propertyId, parsedPropertyId),
-          eq(propertyTransactions.userId, user.id),
-        ),
-      );
+      .where(eq(propertyTransactions.propertyId, parsedPropertyId));
     return c.json({ data });
   }
   const data = await db
-    .select()
+    .select(getTableColumns(propertyTransactions))
     .from(propertyTransactions)
-    .where(eq(propertyTransactions.userId, user.id));
+    .innerJoin(properties, eq(propertyTransactions.propertyId, properties.id))
+    .where(ownedOrJointPredicate(properties, user.id, partnerId));
   return c.json({ data });
 });
 
@@ -1394,10 +1448,8 @@ app.get('/property-transactions/:id', async (c) => {
   const user = getAuthUser(c);
   const id = parseId(c.req.param('id'));
   if (id === null) return c.json({ error: 'Invalid transaction id' }, HTTP_STATUS.BAD_REQUEST);
-  const [data] = await db
-    .select()
-    .from(propertyTransactions)
-    .where(and(eq(propertyTransactions.id, id), eq(propertyTransactions.userId, user.id)));
+  const partnerId = await getAcceptedPartnerId(user.id);
+  const data = await getAccessiblePropertyTransaction(user.id, partnerId, id);
   if (!data) return c.json({ error: 'Transaction not found' }, HTTP_STATUS.NOT_FOUND);
   return c.json({ data });
 });
@@ -1410,7 +1462,8 @@ app.post('/property-transactions', async (c) => {
   const body = parsePropertyTransactionCreate(rawBody.value);
   if (!body.ok) return c.json({ error: body.error }, HTTP_STATUS.BAD_REQUEST);
 
-  const property = await getOwnedProperty(user.id, body.value.propertyId);
+  const partnerId = await getAcceptedPartnerId(user.id);
+  const property = await getAccessibleProperty(user.id, partnerId, body.value.propertyId);
   if (!property) return c.json({ error: 'Property not found' }, HTTP_STATUS.NOT_FOUND);
 
   const validationError = validatePropertyTransactionPayload(body.value, property);
@@ -1418,7 +1471,7 @@ app.post('/property-transactions', async (c) => {
 
   const [data] = await db
     .insert(propertyTransactions)
-    .values(toPropertyTransactionInsertValues(body.value, user.id))
+    .values(toPropertyTransactionInsertValues(body.value, property.userId ?? user.id))
     .returning();
   return c.json({ data }, HTTP_STATUS.CREATED);
 });
@@ -1428,7 +1481,8 @@ app.patch('/property-transactions/:id', async (c) => {
   const id = parseId(c.req.param('id'));
   if (id === null) return c.json({ error: 'Invalid transaction id' }, HTTP_STATUS.BAD_REQUEST);
 
-  const existing = await getOwnedPropertyTransaction(user.id, id);
+  const partnerId = await getAcceptedPartnerId(user.id);
+  const existing = await getAccessiblePropertyTransaction(user.id, partnerId, id);
   if (!existing) return c.json({ error: 'Transaction not found' }, HTTP_STATUS.NOT_FOUND);
 
   const rawBody = await readJsonBody(c.req, 'Invalid property transaction payload');
@@ -1443,7 +1497,7 @@ app.patch('/property-transactions/:id', async (c) => {
   const merged = mergePropertyTransactionPayload(body.value, existing);
   if (!merged.ok) return c.json({ error: merged.error }, HTTP_STATUS.BAD_REQUEST);
 
-  const property = await getOwnedProperty(user.id, merged.value.propertyId);
+  const property = await getAccessibleProperty(user.id, partnerId, merged.value.propertyId);
   if (!property) return c.json({ error: 'Property not found' }, HTTP_STATUS.NOT_FOUND);
 
   const validationError = validatePropertyTransactionPayload(merged.value, property);
@@ -1451,8 +1505,11 @@ app.patch('/property-transactions/:id', async (c) => {
 
   const [data] = await db
     .update(propertyTransactions)
-    .set(toPropertyTransactionUpdateValues(merged.value))
-    .where(and(eq(propertyTransactions.id, id), eq(propertyTransactions.userId, user.id)))
+    .set({
+      ...toPropertyTransactionUpdateValues(merged.value),
+      userId: property.userId ?? user.id,
+    })
+    .where(eq(propertyTransactions.id, id))
     .returning();
   return c.json({ data });
 });
@@ -1461,9 +1518,13 @@ app.delete('/property-transactions/:id', async (c) => {
   const user = getAuthUser(c);
   const id = parseId(c.req.param('id'));
   if (id === null) return c.json({ error: 'Invalid transaction id' }, HTTP_STATUS.BAD_REQUEST);
+  const partnerId = await getAcceptedPartnerId(user.id);
+  const existing = await getAccessiblePropertyTransaction(user.id, partnerId, id);
+  if (!existing) return c.json({ error: 'Transaction not found' }, HTTP_STATUS.NOT_FOUND);
+
   const [data] = await db
     .delete(propertyTransactions)
-    .where(and(eq(propertyTransactions.id, id), eq(propertyTransactions.userId, user.id)))
+    .where(eq(propertyTransactions.id, id))
     .returning();
   if (!data) return c.json({ error: 'Transaction not found' }, HTTP_STATUS.NOT_FOUND);
   return c.json({ data });

--- a/packages/backend/src/routes/mortgages.ts
+++ b/packages/backend/src/routes/mortgages.ts
@@ -6,13 +6,15 @@ import {
 } from '@quro/shared';
 import { db } from '../db/client';
 import { mortgages, mortgageTransactions, properties } from '../db/schema';
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, getTableColumns, isNull } from 'drizzle-orm';
 import { getAuthUser } from '../lib/authUser';
 import { HTTP_STATUS } from '../constants/http';
+import { assertJointAllowed, getAcceptedPartnerId, ownedOrJointPredicate } from '../lib/partner';
 import {
   err,
   isRecord,
   ok,
+  parseBooleanField,
   parseCurrencyField,
   parseDateField,
   parseId,
@@ -44,6 +46,7 @@ const MORTGAGE_FIELDS = [
   'startDate',
   'endDate',
   'overpaymentLimit',
+  'isJoint',
 ] as const;
 const MORTGAGE_TRANSACTION_FIELDS = [
   'mortgageId',
@@ -73,6 +76,7 @@ type MortgagePayload = {
   startDate: string;
   endDate: string;
   overpaymentLimit: number | null;
+  isJoint: boolean;
 };
 
 type MortgageTransactionPayload = {
@@ -99,10 +103,12 @@ function pickPatchedValue<T, U>(patchValue: T | undefined, existingValue: U): T 
 
 type LinkedProperty = {
   id: number;
+  userId: number | null;
   address: string;
   currency: string;
   currentValue: unknown;
   mortgageId: number | null;
+  isJoint: boolean;
 };
 
 function toFiniteNumber(value: unknown): number | null {
@@ -178,6 +184,8 @@ const mortgageParsers: FieldParsers<MortgagePayload> = {
   endDate: (value) => parseTextField(value, 'End date is required'),
   overpaymentLimit: (value) =>
     parseOptionalNormalizedDecimalField(value, 'Overpayment limit must be zero or greater', 0),
+  isJoint: (value) =>
+    value === undefined ? ok(false) : parseBooleanField(value, 'isJoint must be a boolean'),
 };
 
 const mortgageTransactionParsers: FieldParsers<MortgageTransactionPayload> = {
@@ -216,6 +224,7 @@ function resolveNextPropertyId(
 
 async function fetchLinkedProperty(
   userId: number,
+  partnerId: number | null,
   propertyId: number,
   mortgageId: number,
 ): Promise<
@@ -224,13 +233,17 @@ async function fetchLinkedProperty(
   const [property] = await db
     .select({
       id: properties.id,
+      userId: properties.userId,
       address: properties.address,
       currency: properties.currency,
       currentValue: properties.currentValue,
       mortgageId: properties.mortgageId,
+      isJoint: properties.isJoint,
     })
     .from(properties)
-    .where(and(eq(properties.id, propertyId), eq(properties.userId, userId)));
+    .where(
+      and(eq(properties.id, propertyId), ownedOrJointPredicate(properties, userId, partnerId)),
+    );
   if (!property) return { ok: false, error: 'Property not found', status: 404 };
   if (property.mortgageId != null && property.mortgageId !== mortgageId) {
     return { ok: false, error: 'Property already has a linked mortgage', status: 409 };
@@ -242,6 +255,7 @@ async function resolveLinkedProperty(
   rawLinkedPropertyId: unknown,
   currentPropertyId: number | null,
   userId: number,
+  partnerId: number | null,
   mortgageId: number,
 ): Promise<
   | { ok: true; nextId: number | null; property: LinkedProperty | null }
@@ -252,16 +266,16 @@ async function resolveLinkedProperty(
     return { ok: false, error: nextIdResult.error, status: HTTP_STATUS.BAD_REQUEST };
   const nextId = nextIdResult.id;
   if (nextId == null) return { ok: true, nextId: null, property: null };
-  const result = await fetchLinkedProperty(userId, nextId, mortgageId);
+  const result = await fetchLinkedProperty(userId, partnerId, nextId, mortgageId);
   if (!result.ok) return { ok: false, error: result.error, status: result.status };
   return { ok: true, nextId, property: result.property };
 }
 
-async function getOwnedMortgage(userId: number, mortgageId: number) {
+async function getAccessibleMortgage(userId: number, partnerId: number | null, mortgageId: number) {
   const [mortgage] = await db
     .select()
     .from(mortgages)
-    .where(and(eq(mortgages.id, mortgageId), eq(mortgages.userId, userId)));
+    .where(and(eq(mortgages.id, mortgageId), ownedOrJointPredicate(mortgages, userId, partnerId)));
   return mortgage ?? null;
 }
 
@@ -290,19 +304,19 @@ async function readMortgagePatchPayload(
   return body;
 }
 
-async function getCurrentLinkedPropertyId(
-  userId: number,
-  mortgageId: number,
-): Promise<number | null> {
+// The mortgage has already been access-checked, so the linked-property lookup
+// is by mortgageId alone (the property may belong to the partner).
+async function getCurrentLinkedPropertyId(mortgageId: number): Promise<number | null> {
   const [linkedProperty] = await db
     .select({ id: properties.id })
     .from(properties)
-    .where(and(eq(properties.userId, userId), eq(properties.mortgageId, mortgageId)));
+    .where(eq(properties.mortgageId, mortgageId));
   return linkedProperty?.id ?? null;
 }
 
 async function prepareMortgagePatch(params: {
   userId: number;
+  partnerId: number | null;
   mortgageId: number;
   patch: Partial<MortgagePayload>;
 }): Promise<
@@ -312,11 +326,12 @@ async function prepareMortgagePatch(params: {
     }
   | { ok: false; error: string; status: 400 | 404 | 409 }
 > {
-  const currentPropertyId = await getCurrentLinkedPropertyId(params.userId, params.mortgageId);
+  const currentPropertyId = await getCurrentLinkedPropertyId(params.mortgageId);
   const resolved = await resolveLinkedProperty(
     params.patch.linkedPropertyId,
     currentPropertyId,
     params.userId,
+    params.partnerId,
     params.mortgageId,
   );
   if (!resolved.ok) return resolved;
@@ -338,24 +353,27 @@ async function prepareMortgagePatch(params: {
   };
 }
 
+// Property ids come from access-checked resolution, so updates are by id only.
+// Jointness propagates to the linked property to keep the pair's 50% dashboard
+// weighting consistent (equity = value - mortgage balance).
 async function syncLinkedProperty(
-  userId: number,
   prevId: number | null,
   nextId: number | null,
   mortgageId: number,
   balance: unknown,
+  isJoint: boolean,
 ) {
   if (prevId != null && prevId !== nextId) {
     await db
       .update(properties)
       .set({ mortgageId: null, mortgage: 0 } as any)
-      .where(and(eq(properties.id, prevId), eq(properties.userId, userId)));
+      .where(eq(properties.id, prevId));
   }
   if (nextId != null) {
     await db
       .update(properties)
-      .set({ mortgageId, mortgage: balance } as any)
-      .where(and(eq(properties.id, nextId), eq(properties.userId, userId)));
+      .set({ mortgageId, mortgage: balance, isJoint } as any)
+      .where(eq(properties.id, nextId));
   }
 }
 
@@ -502,6 +520,7 @@ function mergeMortgagePayload(
     startDate: pickPatchedValue(patch.startDate, existing.startDate),
     endDate: pickPatchedValue(patch.endDate, existing.endDate),
     overpaymentLimit: pickPatchedValue(patch.overpaymentLimit, existing.overpaymentLimit),
+    isJoint: pickPatchedValue(patch.isJoint, existing.isJoint),
   });
 }
 
@@ -541,6 +560,7 @@ function toMortgageValues(
     startDate: payload.startDate,
     endDate: payload.endDate,
     overpaymentLimit: payload.overpaymentLimit?.toString() ?? null,
+    isJoint: payload.isJoint,
   };
 }
 
@@ -563,15 +583,13 @@ function toMortgageTransactionValues(
 
 app.get('/', async (c) => {
   const user = getAuthUser(c);
+  const partnerId = await getAcceptedPartnerId(user.id);
   const includeArchived = c.req.query('includeArchived') === 'true';
+  const accessPredicate = ownedOrJointPredicate(mortgages, user.id, partnerId);
   const data = await db
     .select()
     .from(mortgages)
-    .where(
-      includeArchived
-        ? eq(mortgages.userId, user.id)
-        : and(eq(mortgages.userId, user.id), isNull(mortgages.archivedAt)),
-    );
+    .where(includeArchived ? accessPredicate : and(accessPredicate, isNull(mortgages.archivedAt)));
   return c.json({ data });
 });
 
@@ -579,26 +597,25 @@ app.get('/', async (c) => {
 
 app.get('/transactions', async (c) => {
   const user = getAuthUser(c);
+  const partnerId = await getAcceptedPartnerId(user.id);
   const mortgageId = c.req.query('mortgageId');
   if (mortgageId) {
     const parsedMortgageId = parseId(mortgageId);
     if (parsedMortgageId === null)
       return c.json({ error: 'Invalid mortgage id' }, HTTP_STATUS.BAD_REQUEST);
+    const mortgage = await getAccessibleMortgage(user.id, partnerId, parsedMortgageId);
+    if (!mortgage) return c.json({ error: 'Mortgage not found' }, HTTP_STATUS.NOT_FOUND);
     const data = await db
       .select()
       .from(mortgageTransactions)
-      .where(
-        and(
-          eq(mortgageTransactions.mortgageId, parsedMortgageId),
-          eq(mortgageTransactions.userId, user.id),
-        ),
-      );
+      .where(eq(mortgageTransactions.mortgageId, parsedMortgageId));
     return c.json({ data });
   }
   const data = await db
-    .select()
+    .select(getTableColumns(mortgageTransactions))
     .from(mortgageTransactions)
-    .where(eq(mortgageTransactions.userId, user.id));
+    .innerJoin(mortgages, eq(mortgageTransactions.mortgageId, mortgages.id))
+    .where(ownedOrJointPredicate(mortgages, user.id, partnerId));
   return c.json({ data });
 });
 
@@ -606,10 +623,8 @@ app.get('/:id', async (c) => {
   const user = getAuthUser(c);
   const id = parseId(c.req.param('id'));
   if (id === null) return c.json({ error: 'Invalid mortgage id' }, HTTP_STATUS.BAD_REQUEST);
-  const [data] = await db
-    .select()
-    .from(mortgages)
-    .where(and(eq(mortgages.id, id), eq(mortgages.userId, user.id)));
+  const partnerId = await getAcceptedPartnerId(user.id);
+  const data = await getAccessibleMortgage(user.id, partnerId, id);
   if (!data) return c.json({ error: 'Mortgage not found' }, HTTP_STATUS.NOT_FOUND);
   return c.json({ data });
 });
@@ -631,7 +646,8 @@ app.post('/', async (c) => {
   if (!linkedPropertyId.ok)
     return c.json({ error: linkedPropertyId.error }, HTTP_STATUS.BAD_REQUEST);
 
-  const propertyResult = await fetchLinkedProperty(user.id, linkedPropertyId.value, 0);
+  const partnerId = await getAcceptedPartnerId(user.id);
+  const propertyResult = await fetchLinkedProperty(user.id, partnerId, linkedPropertyId.value, 0);
   if (!propertyResult.ok) return c.json({ error: propertyResult.error }, propertyResult.status);
   const property = propertyResult.property;
   const propertyValue = toFiniteNumber(property.currentValue);
@@ -647,10 +663,15 @@ app.post('/', async (c) => {
   });
   if (!body.ok) return c.json({ error: body.error }, HTTP_STATUS.BAD_REQUEST);
 
+  // A mortgage linked to a joint property is joint too (and vice versa).
+  const isJoint = body.value.isJoint || property.isJoint;
+  const jointError = await assertJointAllowed(user.id, isJoint);
+  if (jointError) return c.json({ error: jointError }, HTTP_STATUS.BAD_REQUEST);
+
   const [data] = await db
     .insert(mortgages)
     .values({
-      ...toMortgageValues(body.value, property),
+      ...toMortgageValues({ ...body.value, isJoint }, property),
       userId: user.id,
     })
     .returning();
@@ -660,8 +681,9 @@ app.post('/', async (c) => {
     .set({
       mortgageId: data.id,
       mortgage: body.value.outstandingBalance.toString(),
+      isJoint,
     })
-    .where(and(eq(properties.id, property.id), eq(properties.userId, user.id)));
+    .where(eq(properties.id, property.id));
 
   return c.json({ data }, HTTP_STATUS.CREATED);
 });
@@ -671,13 +693,15 @@ app.patch('/:id', async (c) => {
   const id = parseId(c.req.param('id'));
   if (id === null) return c.json({ error: 'Invalid mortgage id' }, HTTP_STATUS.BAD_REQUEST);
 
-  const existingMortgage = await getOwnedMortgage(user.id, id);
+  const partnerId = await getAcceptedPartnerId(user.id);
+  const existingMortgage = await getAccessibleMortgage(user.id, partnerId, id);
   if (!existingMortgage) return c.json({ error: 'Mortgage not found' }, HTTP_STATUS.NOT_FOUND);
 
   const body = await readMortgagePatchPayload(c.req);
   if (!body.ok) return c.json({ error: body.error }, body.status);
   const patchContext = await prepareMortgagePatch({
     userId: user.id,
+    partnerId,
     mortgageId: id,
     patch: body.value,
   });
@@ -690,18 +714,21 @@ app.patch('/:id', async (c) => {
   );
   if (!merged.ok) return c.json({ error: merged.error }, HTTP_STATUS.BAD_REQUEST);
 
+  const jointError = await assertJointAllowed(user.id, merged.value.isJoint);
+  if (jointError) return c.json({ error: jointError }, HTTP_STATUS.BAD_REQUEST);
+
   const [data] = await db
     .update(mortgages)
     .set(toMortgageValues(merged.value, patchContext.value.property))
-    .where(and(eq(mortgages.id, id), eq(mortgages.userId, user.id)))
+    .where(eq(mortgages.id, id))
     .returning();
 
   await syncLinkedProperty(
-    user.id,
     patchContext.value.currentPropertyId,
     patchContext.value.nextPropertyId,
     id,
     merged.value.outstandingBalance.toString(),
+    merged.value.isJoint,
   );
   return c.json({ data });
 });
@@ -711,31 +738,34 @@ app.delete('/:id', async (c) => {
   const id = parseId(c.req.param('id'));
   if (id === null) return c.json({ error: 'Invalid mortgage id' }, HTTP_STATUS.BAD_REQUEST);
 
+  const partnerId = await getAcceptedPartnerId(user.id);
+  const accessPredicate = and(
+    eq(mortgages.id, id),
+    ownedOrJointPredicate(mortgages, user.id, partnerId),
+  );
+
   if (c.req.query('cascade') === 'true') {
+    const [data] = await db.delete(mortgages).where(accessPredicate).returning();
+    if (!data) return c.json({ error: 'Mortgage not found' }, HTTP_STATUS.NOT_FOUND);
+
     await db
       .update(properties)
       .set({ mortgageId: null, mortgage: 0 } as any)
-      .where(and(eq(properties.mortgageId, id), eq(properties.userId, user.id)));
-
-    const [data] = await db
-      .delete(mortgages)
-      .where(and(eq(mortgages.id, id), eq(mortgages.userId, user.id)))
-      .returning();
-    if (!data) return c.json({ error: 'Mortgage not found' }, HTTP_STATUS.NOT_FOUND);
+      .where(eq(properties.mortgageId, id));
     return c.json({ data });
   }
 
   const [data] = await db
     .update(mortgages)
     .set({ archivedAt: new Date() })
-    .where(and(eq(mortgages.id, id), eq(mortgages.userId, user.id), isNull(mortgages.archivedAt)))
+    .where(and(accessPredicate, isNull(mortgages.archivedAt)))
     .returning();
   if (!data) return c.json({ error: 'Mortgage not found' }, HTTP_STATUS.NOT_FOUND);
 
   await db
     .update(properties)
     .set({ mortgageId: null, mortgage: 0 } as any)
-    .where(and(eq(properties.mortgageId, id), eq(properties.userId, user.id)));
+    .where(eq(properties.mortgageId, id));
 
   return c.json({ data });
 });
@@ -745,10 +775,11 @@ app.post('/:id/unarchive', async (c) => {
   const id = parseId(c.req.param('id'));
   if (id === null) return c.json({ error: 'Invalid mortgage id' }, HTTP_STATUS.BAD_REQUEST);
 
+  const partnerId = await getAcceptedPartnerId(user.id);
   const [data] = await db
     .update(mortgages)
     .set({ archivedAt: null })
-    .where(and(eq(mortgages.id, id), eq(mortgages.userId, user.id)))
+    .where(and(eq(mortgages.id, id), ownedOrJointPredicate(mortgages, user.id, partnerId)))
     .returning();
   if (!data) return c.json({ error: 'Mortgage not found' }, HTTP_STATUS.NOT_FOUND);
   return c.json({ data });
@@ -758,10 +789,14 @@ app.get('/transactions/:id', async (c) => {
   const user = getAuthUser(c);
   const id = parseId(c.req.param('id'));
   if (id === null) return c.json({ error: 'Invalid transaction id' }, HTTP_STATUS.BAD_REQUEST);
+  const partnerId = await getAcceptedPartnerId(user.id);
   const [data] = await db
-    .select()
+    .select(getTableColumns(mortgageTransactions))
     .from(mortgageTransactions)
-    .where(and(eq(mortgageTransactions.id, id), eq(mortgageTransactions.userId, user.id)));
+    .innerJoin(mortgages, eq(mortgageTransactions.mortgageId, mortgages.id))
+    .where(
+      and(eq(mortgageTransactions.id, id), ownedOrJointPredicate(mortgages, user.id, partnerId)),
+    );
   if (!data) return c.json({ error: 'Transaction not found' }, HTTP_STATUS.NOT_FOUND);
   return c.json({ data });
 });
@@ -774,15 +809,13 @@ app.post('/transactions', async (c) => {
   const body = parseMortgageTransactionCreate(rawBody.value);
   if (!body.ok) return c.json({ error: body.error }, HTTP_STATUS.BAD_REQUEST);
 
-  const [mortgage] = await db
-    .select({ id: mortgages.id })
-    .from(mortgages)
-    .where(and(eq(mortgages.id, body.value.mortgageId), eq(mortgages.userId, user.id)));
+  const partnerId = await getAcceptedPartnerId(user.id);
+  const mortgage = await getAccessibleMortgage(user.id, partnerId, body.value.mortgageId);
   if (!mortgage) return c.json({ error: 'Mortgage not found' }, HTTP_STATUS.NOT_FOUND);
 
   const [data] = await db
     .insert(mortgageTransactions)
-    .values({ ...toMortgageTransactionValues(body.value), userId: user.id })
+    .values({ ...toMortgageTransactionValues(body.value), userId: mortgage.userId ?? user.id })
     .returning();
   return c.json({ data }, HTTP_STATUS.CREATED);
 });
@@ -792,10 +825,14 @@ app.patch('/transactions/:id', async (c) => {
   const id = parseId(c.req.param('id'));
   if (id === null) return c.json({ error: 'Invalid transaction id' }, HTTP_STATUS.BAD_REQUEST);
 
+  const partnerId = await getAcceptedPartnerId(user.id);
   const [existing] = await db
-    .select()
+    .select(getTableColumns(mortgageTransactions))
     .from(mortgageTransactions)
-    .where(and(eq(mortgageTransactions.id, id), eq(mortgageTransactions.userId, user.id)));
+    .innerJoin(mortgages, eq(mortgageTransactions.mortgageId, mortgages.id))
+    .where(
+      and(eq(mortgageTransactions.id, id), ownedOrJointPredicate(mortgages, user.id, partnerId)),
+    );
   if (!existing) return c.json({ error: 'Transaction not found' }, HTTP_STATUS.NOT_FOUND);
 
   const rawBody = await readJsonBody(c.req, 'Invalid mortgage transaction payload');
@@ -810,16 +847,13 @@ app.patch('/transactions/:id', async (c) => {
   const merged = mergeMortgageTransactionPayload(body.value, existing);
   if (!merged.ok) return c.json({ error: merged.error }, HTTP_STATUS.BAD_REQUEST);
 
-  const [mortgage] = await db
-    .select({ id: mortgages.id })
-    .from(mortgages)
-    .where(and(eq(mortgages.id, merged.value.mortgageId), eq(mortgages.userId, user.id)));
+  const mortgage = await getAccessibleMortgage(user.id, partnerId, merged.value.mortgageId);
   if (!mortgage) return c.json({ error: 'Mortgage not found' }, HTTP_STATUS.NOT_FOUND);
 
   const [data] = await db
     .update(mortgageTransactions)
-    .set(toMortgageTransactionValues(merged.value))
-    .where(and(eq(mortgageTransactions.id, id), eq(mortgageTransactions.userId, user.id)))
+    .set({ ...toMortgageTransactionValues(merged.value), userId: mortgage.userId ?? user.id })
+    .where(eq(mortgageTransactions.id, id))
     .returning();
   return c.json({ data });
 });
@@ -828,9 +862,19 @@ app.delete('/transactions/:id', async (c) => {
   const user = getAuthUser(c);
   const id = parseId(c.req.param('id'));
   if (id === null) return c.json({ error: 'Invalid transaction id' }, HTTP_STATUS.BAD_REQUEST);
+  const partnerId = await getAcceptedPartnerId(user.id);
+  const [existing] = await db
+    .select({ id: mortgageTransactions.id })
+    .from(mortgageTransactions)
+    .innerJoin(mortgages, eq(mortgageTransactions.mortgageId, mortgages.id))
+    .where(
+      and(eq(mortgageTransactions.id, id), ownedOrJointPredicate(mortgages, user.id, partnerId)),
+    );
+  if (!existing) return c.json({ error: 'Transaction not found' }, HTTP_STATUS.NOT_FOUND);
+
   const [data] = await db
     .delete(mortgageTransactions)
-    .where(and(eq(mortgageTransactions.id, id), eq(mortgageTransactions.userId, user.id)))
+    .where(eq(mortgageTransactions.id, id))
     .returning();
   if (!data) return c.json({ error: 'Transaction not found' }, HTTP_STATUS.NOT_FOUND);
   return c.json({ data });

--- a/packages/backend/src/routes/partner.integration.test.ts
+++ b/packages/backend/src/routes/partner.integration.test.ts
@@ -1,0 +1,643 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { createIntegrationHelpers, type AuthSession } from '../test/integration';
+
+const integration = createIntegrationHelpers('partner-it.quro.test');
+
+type ApiDataResponse<T> = { data: T };
+type ApiErrorResponse = { error: string };
+
+type PartnerLinkBody = {
+  id: number;
+  status: 'pending' | 'accepted';
+  role: 'requester' | 'addressee';
+  partner: { id: number; firstName: string; lastName: string; email: string };
+};
+
+async function parseJson<T>(response: Response, expectedStatus: number): Promise<T> {
+  expect(response.status).toBe(expectedStatus);
+  return (await response.json()) as T;
+}
+
+function invitePartner(from: AuthSession, email: string): Promise<Response> {
+  return Promise.resolve(
+    integration.request('/api/partner/invite', {
+      method: 'POST',
+      cookie: from.cookie,
+      json: { email },
+    }),
+  );
+}
+
+async function linkPartners(requester: AuthSession, addressee: AuthSession): Promise<void> {
+  await parseJson(await invitePartner(requester, addressee.user.email), 201);
+  await parseJson(
+    await integration.request('/api/partner/accept', {
+      method: 'POST',
+      cookie: addressee.cookie,
+    }),
+    200,
+  );
+}
+
+function unlinkPartner(session: AuthSession): Promise<Response> {
+  return Promise.resolve(
+    integration.request('/api/partner', { method: 'DELETE', cookie: session.cookie }),
+  );
+}
+
+async function getPartnerLink(session: AuthSession): Promise<PartnerLinkBody | null> {
+  const body = await parseJson<ApiDataResponse<PartnerLinkBody | null>>(
+    await integration.request('/api/partner', { cookie: session.cookie }),
+    200,
+  );
+  return body.data;
+}
+
+async function createSavingsAccount(
+  session: AuthSession,
+  overrides: Record<string, unknown> = {},
+): Promise<{ id: number; balance: string; isJoint: boolean; userId: number }> {
+  const body = await parseJson<
+    ApiDataResponse<{ id: number; balance: string; isJoint: boolean; userId: number }>
+  >(
+    await integration.request('/api/savings/accounts', {
+      method: 'POST',
+      cookie: session.cookie,
+      json: {
+        name: 'Joint Test Account',
+        bank: 'Test Bank',
+        balance: 1000,
+        currency: 'EUR',
+        interestRate: 2,
+        accountType: 'Easy Access',
+        color: '#fff',
+        emoji: 'S',
+        ...overrides,
+      },
+    }),
+    201,
+  );
+  return body.data;
+}
+
+async function createProperty(
+  session: AuthSession,
+  overrides: Record<string, unknown> = {},
+): Promise<{ id: number; isJoint: boolean; mortgageId: number | null }> {
+  const body = await parseJson<
+    ApiDataResponse<{ id: number; isJoint: boolean; mortgageId: number | null }>
+  >(
+    await integration.request('/api/investments/properties', {
+      method: 'POST',
+      cookie: session.cookie,
+      json: {
+        address: '1 Shared Lane',
+        propertyType: 'primary_home',
+        purchasePrice: 280000,
+        currentValue: 300000,
+        monthlyRent: 0,
+        currency: 'EUR',
+        emoji: 'H',
+        ...overrides,
+      },
+    }),
+    201,
+  );
+  return body.data;
+}
+
+async function createMortgage(
+  session: AuthSession,
+  linkedPropertyId: number,
+  overrides: Record<string, unknown> = {},
+): Promise<{ id: number; isJoint: boolean; outstandingBalance: string }> {
+  const body = await parseJson<
+    ApiDataResponse<{ id: number; isJoint: boolean; outstandingBalance: string }>
+  >(
+    await integration.request('/api/mortgages', {
+      method: 'POST',
+      cookie: session.cookie,
+      json: {
+        linkedPropertyId,
+        lender: 'Test Lender',
+        originalAmount: 250000,
+        outstandingBalance: 200000,
+        propertyValue: 300000,
+        monthlyPayment: 1200,
+        interestRate: 3.1,
+        rateType: 'fixed',
+        fixedUntil: '2031-01-01',
+        termYears: 30,
+        startDate: '2021-01-01',
+        endDate: '2051-01-01',
+        overpaymentLimit: 10,
+        ...overrides,
+      },
+    }),
+    201,
+  );
+  return body.data;
+}
+
+function getSavingsAccount(session: AuthSession, id: number): Promise<Response> {
+  return Promise.resolve(
+    integration.request(`/api/savings/accounts/${id}`, { cookie: session.cookie }),
+  );
+}
+
+describe('partner link lifecycle', () => {
+  beforeAll(async () => {
+    await integration.cleanup();
+  });
+
+  afterAll(async () => {
+    await integration.cleanup();
+  });
+
+  test('invite, accept, and unlink round trip with correct roles', async () => {
+    const alice = await integration.signUp('alice', { firstName: 'Alice', lastName: 'A' });
+    const ben = await integration.signUp('ben', { firstName: 'Ben', lastName: 'B' });
+
+    const inviteBody = await parseJson<ApiDataResponse<PartnerLinkBody>>(
+      await invitePartner(alice, ben.user.email.toUpperCase()),
+      201,
+    );
+    expect(inviteBody.data).toMatchObject({
+      status: 'pending',
+      role: 'requester',
+      partner: { id: ben.user.id, email: ben.user.email },
+    });
+
+    const benView = await getPartnerLink(ben);
+    expect(benView).toMatchObject({
+      status: 'pending',
+      role: 'addressee',
+      partner: { id: alice.user.id, firstName: 'Alice' },
+    });
+
+    await parseJson(
+      await integration.request('/api/partner/accept', { method: 'POST', cookie: ben.cookie }),
+      200,
+    );
+
+    expect(await getPartnerLink(alice)).toMatchObject({ status: 'accepted', role: 'requester' });
+    expect(await getPartnerLink(ben)).toMatchObject({ status: 'accepted', role: 'addressee' });
+
+    await parseJson(await unlinkPartner(alice), 200);
+    expect(await getPartnerLink(alice)).toBeNull();
+    expect(await getPartnerLink(ben)).toBeNull();
+  });
+
+  test('validates invites: unknown email, self-invite, and existing links', async () => {
+    const carol = await integration.signUp('carol');
+    const dave = await integration.signUp('dave');
+    const erin = await integration.signUp('erin');
+
+    const unknownResponse = await invitePartner(carol, integration.buildEmail('nobody'));
+    expect(unknownResponse.status).toBe(404);
+
+    const selfResponse = await invitePartner(carol, carol.user.email);
+    expect(selfResponse.status).toBe(400);
+
+    await parseJson(await invitePartner(carol, dave.user.email), 201);
+
+    const doubleInvite = await invitePartner(carol, erin.user.email);
+    expect(doubleInvite.status).toBe(409);
+
+    const inviteTaken = await invitePartner(erin, dave.user.email);
+    expect(inviteTaken.status).toBe(409);
+
+    // Requester cannot accept their own invite.
+    const requesterAccept = await integration.request('/api/partner/accept', {
+      method: 'POST',
+      cookie: carol.cookie,
+    });
+    expect(requesterAccept.status).toBe(404);
+
+    // Addressee declines; both sides are clear again.
+    await parseJson(
+      await integration.request('/api/partner/decline', { method: 'POST', cookie: dave.cookie }),
+      200,
+    );
+    expect(await getPartnerLink(carol)).toBeNull();
+
+    // Accept with nothing pending is a 404.
+    const staleAccept = await integration.request('/api/partner/accept', {
+      method: 'POST',
+      cookie: dave.cookie,
+    });
+    expect(staleAccept.status).toBe(404);
+
+    // Requester can cancel a pending invite via DELETE.
+    await parseJson(await invitePartner(carol, dave.user.email), 201);
+    await parseJson(await unlinkPartner(carol), 200);
+    expect(await getPartnerLink(dave)).toBeNull();
+  });
+
+  test('rejects isJoint without an accepted link (none or pending)', async () => {
+    const frank = await integration.signUp('frank');
+    const grace = await integration.signUp('grace');
+
+    const noLinkResponse = await integration.request('/api/savings/accounts', {
+      method: 'POST',
+      cookie: frank.cookie,
+      json: {
+        name: 'Solo',
+        bank: 'Bank',
+        balance: 100,
+        currency: 'EUR',
+        interestRate: 1,
+        accountType: 'Easy Access',
+        color: '#fff',
+        emoji: 'S',
+        isJoint: true,
+      },
+    });
+    const noLinkBody = await parseJson<ApiErrorResponse>(noLinkResponse, 400);
+    expect(noLinkBody.error).toBe('No partner linked');
+
+    await parseJson(await invitePartner(frank, grace.user.email), 201);
+    const pendingResponse = await integration.request('/api/savings/accounts', {
+      method: 'POST',
+      cookie: frank.cookie,
+      json: {
+        name: 'Still Solo',
+        bank: 'Bank',
+        balance: 100,
+        currency: 'EUR',
+        interestRate: 1,
+        accountType: 'Easy Access',
+        color: '#fff',
+        emoji: 'S',
+        isJoint: true,
+      },
+    });
+    expect(pendingResponse.status).toBe(400);
+  });
+});
+
+describe('joint savings access', () => {
+  beforeAll(async () => {
+    await integration.cleanup();
+  });
+
+  afterAll(async () => {
+    await integration.cleanup();
+  });
+
+  test('partner has full access to joint accounts and their transactions', async () => {
+    const owner = await integration.signUp('joint-owner');
+    const partner = await integration.signUp('joint-partner');
+    const stranger = await integration.signUp('joint-stranger');
+    await linkPartners(owner, partner);
+
+    const jointAccount = await createSavingsAccount(owner, { isJoint: true, balance: 1000 });
+    const personalAccount = await createSavingsAccount(owner, {
+      name: 'Personal',
+      isJoint: false,
+    });
+
+    // Partner sees the joint account (and not the personal one) in lists.
+    const partnerList = await parseJson<ApiDataResponse<Array<{ id: number }>>>(
+      await integration.request('/api/savings/accounts', { cookie: partner.cookie }),
+      200,
+    );
+    expect(partnerList.data.map((account) => account.id)).toEqual([jointAccount.id]);
+
+    expect((await getSavingsAccount(partner, jointAccount.id)).status).toBe(200);
+    expect((await getSavingsAccount(partner, personalAccount.id)).status).toBe(404);
+    expect((await getSavingsAccount(stranger, jointAccount.id)).status).toBe(404);
+
+    // Partner can edit the joint account.
+    await parseJson(
+      await integration.request(`/api/savings/accounts/${jointAccount.id}`, {
+        method: 'PATCH',
+        cookie: partner.cookie,
+        json: { name: 'Renamed by partner' },
+      }),
+      200,
+    );
+
+    // Partner adds a deposit: the row carries the owner's userId and the
+    // balance updates (regression test for the user-scoped balance helper).
+    const txnBody = await parseJson<ApiDataResponse<{ id: number; userId: number }>>(
+      await integration.request('/api/savings/transactions', {
+        method: 'POST',
+        cookie: partner.cookie,
+        json: {
+          accountId: jointAccount.id,
+          type: 'deposit',
+          amount: 500,
+          date: '2026-06-01',
+          note: 'Partner deposit',
+        },
+      }),
+      201,
+    );
+    expect(txnBody.data.userId).toBe(owner.user.id);
+
+    const afterDeposit = await parseJson<ApiDataResponse<{ balance: string }>>(
+      await getSavingsAccount(owner, jointAccount.id),
+      200,
+    );
+    expect(Number(afterDeposit.data.balance)).toBe(1500);
+
+    // Both see the transaction; the partner can edit and delete it.
+    const ownerTxns = await parseJson<ApiDataResponse<Array<{ id: number }>>>(
+      await integration.request(`/api/savings/transactions?accountId=${jointAccount.id}`, {
+        cookie: owner.cookie,
+      }),
+      200,
+    );
+    expect(ownerTxns.data.map((txn) => txn.id)).toEqual([txnBody.data.id]);
+
+    await parseJson(
+      await integration.request(`/api/savings/transactions/${txnBody.data.id}`, {
+        method: 'PATCH',
+        cookie: partner.cookie,
+        json: { amount: 700 },
+      }),
+      200,
+    );
+    const afterEdit = await parseJson<ApiDataResponse<{ balance: string }>>(
+      await getSavingsAccount(owner, jointAccount.id),
+      200,
+    );
+    expect(Number(afterEdit.data.balance)).toBe(1700);
+
+    await parseJson(
+      await integration.request(`/api/savings/transactions/${txnBody.data.id}`, {
+        method: 'DELETE',
+        cookie: partner.cookie,
+      }),
+      200,
+    );
+    const afterDelete = await parseJson<ApiDataResponse<{ balance: string }>>(
+      await getSavingsAccount(owner, jointAccount.id),
+      200,
+    );
+    expect(Number(afterDelete.data.balance)).toBe(1000);
+
+    // Partner can archive and unarchive the joint account.
+    await parseJson(
+      await integration.request(`/api/savings/accounts/${jointAccount.id}`, {
+        method: 'DELETE',
+        cookie: partner.cookie,
+      }),
+      200,
+    );
+    await parseJson(
+      await integration.request(`/api/savings/accounts/${jointAccount.id}/unarchive`, {
+        method: 'POST',
+        cookie: partner.cookie,
+      }),
+      200,
+    );
+
+    // Stranger cannot touch anything.
+    const strangerPatch = await integration.request(`/api/savings/accounts/${jointAccount.id}`, {
+      method: 'PATCH',
+      cookie: stranger.cookie,
+      json: { name: 'Hacked' },
+    });
+    expect(strangerPatch.status).toBe(404);
+  });
+
+  test('unlink resets joint flags and revokes partner access', async () => {
+    const owner = await integration.signUp('unlink-owner');
+    const partner = await integration.signUp('unlink-partner');
+    await linkPartners(owner, partner);
+
+    const jointAccount = await createSavingsAccount(owner, { isJoint: true });
+    await parseJson(
+      await integration.request('/api/savings/transactions', {
+        method: 'POST',
+        cookie: partner.cookie,
+        json: {
+          accountId: jointAccount.id,
+          type: 'deposit',
+          amount: 250,
+          date: '2026-06-02',
+          note: 'Before unlink',
+        },
+      }),
+      201,
+    );
+
+    await parseJson(await unlinkPartner(partner), 200);
+
+    // Partner loses access; owner keeps the account, the flag resets, and the
+    // partner-created transaction survives with the owner.
+    expect((await getSavingsAccount(partner, jointAccount.id)).status).toBe(404);
+    const ownerView = await parseJson<ApiDataResponse<{ isJoint: boolean; balance: string }>>(
+      await getSavingsAccount(owner, jointAccount.id),
+      200,
+    );
+    expect(ownerView.data.isJoint).toBe(false);
+    expect(Number(ownerView.data.balance)).toBe(1250);
+
+    const ownerTxns = await parseJson<ApiDataResponse<Array<{ note: string | null }>>>(
+      await integration.request(`/api/savings/transactions?accountId=${jointAccount.id}`, {
+        cookie: owner.cookie,
+      }),
+      200,
+    );
+    expect(ownerTxns.data.map((txn) => txn.note)).toEqual(['Before unlink']);
+  });
+});
+
+describe('joint properties and mortgages', () => {
+  beforeAll(async () => {
+    await integration.cleanup();
+  });
+
+  afterAll(async () => {
+    await integration.cleanup();
+  });
+
+  test('jointness propagates across the property-mortgage link in both directions', async () => {
+    const owner = await integration.signUp('prop-owner');
+    const partner = await integration.signUp('prop-partner');
+    await linkPartners(owner, partner);
+
+    // Mortgage created against a joint property inherits jointness.
+    const jointProperty = await createProperty(owner, { isJoint: true });
+    const mortgage = await createMortgage(owner, jointProperty.id);
+    expect(mortgage.isJoint).toBe(true);
+
+    // Partner can see and transact on both sides of the pair.
+    const partnerMortgage = await parseJson<ApiDataResponse<{ id: number }>>(
+      await integration.request(`/api/mortgages/${mortgage.id}`, { cookie: partner.cookie }),
+      200,
+    );
+    expect(partnerMortgage.data.id).toBe(mortgage.id);
+
+    const mortgageTxn = await parseJson<ApiDataResponse<{ id: number; userId: number }>>(
+      await integration.request('/api/mortgages/transactions', {
+        method: 'POST',
+        cookie: partner.cookie,
+        json: {
+          mortgageId: mortgage.id,
+          type: 'repayment',
+          amount: 1200,
+          interest: 500,
+          principal: 700,
+          date: '2026-06-01',
+          note: 'Partner repayment',
+        },
+      }),
+      201,
+    );
+    expect(mortgageTxn.data.userId).toBe(owner.user.id);
+
+    const ownerMortgageTxns = await parseJson<ApiDataResponse<Array<{ id: number }>>>(
+      await integration.request(`/api/mortgages/transactions?mortgageId=${mortgage.id}`, {
+        cookie: owner.cookie,
+      }),
+      200,
+    );
+    expect(ownerMortgageTxns.data.map((txn) => txn.id)).toEqual([mortgageTxn.data.id]);
+
+    const propertyTxn = await parseJson<ApiDataResponse<{ id: number; userId: number }>>(
+      await integration.request('/api/investments/property-transactions', {
+        method: 'POST',
+        cookie: partner.cookie,
+        json: {
+          propertyId: jointProperty.id,
+          type: 'valuation',
+          amount: 310000,
+          date: '2026-06-03',
+          note: 'Partner valuation',
+        },
+      }),
+      201,
+    );
+    expect(propertyTxn.data.userId).toBe(owner.user.id);
+
+    // Un-marking the property un-marks the linked mortgage.
+    await parseJson(
+      await integration.request(`/api/investments/properties/${jointProperty.id}`, {
+        method: 'PATCH',
+        cookie: owner.cookie,
+        json: { isJoint: false },
+      }),
+      200,
+    );
+    const unmarkedMortgage = await parseJson<ApiDataResponse<{ isJoint: boolean }>>(
+      await integration.request(`/api/mortgages/${mortgage.id}`, { cookie: owner.cookie }),
+      200,
+    );
+    expect(unmarkedMortgage.data.isJoint).toBe(false);
+
+    // Marking the mortgage joint again marks the property.
+    await parseJson(
+      await integration.request(`/api/mortgages/${mortgage.id}`, {
+        method: 'PATCH',
+        cookie: owner.cookie,
+        json: { isJoint: true },
+      }),
+      200,
+    );
+    const remarkedProperty = await parseJson<ApiDataResponse<{ isJoint: boolean }>>(
+      await integration.request(`/api/investments/properties/${jointProperty.id}`, {
+        cookie: owner.cookie,
+      }),
+      200,
+    );
+    expect(remarkedProperty.data.isJoint).toBe(true);
+  });
+});
+
+describe('dashboard joint weighting', () => {
+  beforeAll(async () => {
+    await integration.cleanup();
+  });
+
+  afterAll(async () => {
+    await integration.cleanup();
+  });
+
+  test('joint assets count at 50% in allocations for both partners', async () => {
+    const alice = await integration.signUp('dash-alice');
+    const ben = await integration.signUp('dash-ben');
+    await linkPartners(alice, ben);
+
+    // Alice: 1000 EUR personal + 500 EUR joint savings.
+    await createSavingsAccount(alice, { name: 'Solo', balance: 1000 });
+    await createSavingsAccount(alice, { name: 'Shared', balance: 500, isJoint: true });
+
+    // Ben: joint property worth 300k with a joint mortgage of 200k.
+    const property = await createProperty(ben, { isJoint: true });
+    await createMortgage(ben, property.id);
+
+    const aliceAllocations = await parseJson<
+      ApiDataResponse<{ allocations: Array<{ name: string; value: number }> }>
+    >(await integration.request('/api/dashboard/allocations', { cookie: alice.cookie }), 200);
+    const aliceSavings = aliceAllocations.data.allocations.find((a) => a.name === 'Savings');
+    const aliceEquity = aliceAllocations.data.allocations.find((a) => a.name === 'Property Equity');
+    expect(aliceSavings?.value).toBe(1250);
+    expect(aliceEquity?.value).toBe(50000);
+
+    const benAllocations = await parseJson<
+      ApiDataResponse<{ allocations: Array<{ name: string; value: number }> }>
+    >(await integration.request('/api/dashboard/allocations', { cookie: ben.cookie }), 200);
+    const benSavings = benAllocations.data.allocations.find((a) => a.name === 'Savings');
+    const benEquity = benAllocations.data.allocations.find((a) => a.name === 'Property Equity');
+    expect(benSavings?.value).toBe(250);
+    expect(benEquity?.value).toBe(50000);
+  });
+
+  test('activity feed flags partner joint transactions with full amounts', async () => {
+    const alice = await integration.signUp('feed-alice');
+    const ben = await integration.signUp('feed-ben');
+    await linkPartners(alice, ben);
+
+    const jointAccount = await createSavingsAccount(alice, { isJoint: true, balance: 0 });
+    const personalAccount = await createSavingsAccount(alice, { name: 'Solo', balance: 0 });
+
+    await parseJson(
+      await integration.request('/api/savings/transactions', {
+        method: 'POST',
+        cookie: alice.cookie,
+        json: {
+          accountId: jointAccount.id,
+          type: 'deposit',
+          amount: 500,
+          date: '2026-06-05',
+          note: 'Joint deposit',
+        },
+      }),
+      201,
+    );
+    await parseJson(
+      await integration.request('/api/savings/transactions', {
+        method: 'POST',
+        cookie: alice.cookie,
+        json: {
+          accountId: personalAccount.id,
+          type: 'deposit',
+          amount: 200,
+          date: '2026-06-05',
+          note: 'Personal deposit',
+        },
+      }),
+      201,
+    );
+
+    const benFeed = await parseJson<
+      ApiDataResponse<Array<{ name: string; amount: number; isJoint: boolean }>>
+    >(await integration.request('/api/dashboard/transactions', { cookie: ben.cookie }), 200);
+
+    const jointRow = benFeed.data.find((row) => row.name === 'Joint deposit');
+    expect(jointRow).toMatchObject({ isJoint: true, amount: -500 });
+    expect(benFeed.data.find((row) => row.name === 'Personal deposit')).toBeUndefined();
+
+    const aliceFeed = await parseJson<
+      ApiDataResponse<Array<{ name: string; amount: number; isJoint: boolean }>>
+    >(await integration.request('/api/dashboard/transactions', { cookie: alice.cookie }), 200);
+    expect(aliceFeed.data.find((row) => row.name === 'Personal deposit')).toMatchObject({
+      isJoint: false,
+      amount: -200,
+    });
+  });
+});

--- a/packages/backend/src/routes/partner.ts
+++ b/packages/backend/src/routes/partner.ts
@@ -1,0 +1,192 @@
+import { Hono } from 'hono';
+import { and, eq, inArray, or } from 'drizzle-orm';
+import type { PartnerLink, PartnerProfile } from '@quro/shared';
+import { db } from '../db/client';
+import { mortgages, partnerLinks, properties, savingsAccounts, users } from '../db/schema';
+import { HTTP_STATUS } from '../constants/http';
+import { getAuthUser } from '../lib/authUser';
+
+const app = new Hono();
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PG_UNIQUE_VIOLATION = '23505';
+
+type PartnerLinkRow = typeof partnerLinks.$inferSelect;
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code: unknown }).code === PG_UNIQUE_VIOLATION
+  );
+}
+
+function linkInvolving(userId: number) {
+  return or(eq(partnerLinks.requesterId, userId), eq(partnerLinks.addresseeId, userId));
+}
+
+async function findLinkInvolving(userId: number): Promise<PartnerLinkRow | null> {
+  const [link] = await db.select().from(partnerLinks).where(linkInvolving(userId));
+  return link ?? null;
+}
+
+async function getPartnerProfile(partnerId: number): Promise<PartnerProfile | null> {
+  const [profile] = await db
+    .select({
+      id: users.id,
+      firstName: users.firstName,
+      lastName: users.lastName,
+      email: users.email,
+    })
+    .from(users)
+    .where(eq(users.id, partnerId));
+  return profile ?? null;
+}
+
+async function toPartnerLinkResponse(
+  link: PartnerLinkRow,
+  userId: number,
+): Promise<PartnerLink | null> {
+  const role = link.requesterId === userId ? 'requester' : 'addressee';
+  const partnerId = role === 'requester' ? link.addresseeId : link.requesterId;
+  const partner = await getPartnerProfile(partnerId);
+  if (!partner) return null;
+  return {
+    id: link.id,
+    status: link.status,
+    role,
+    createdAt: link.createdAt.toISOString(),
+    partner,
+  };
+}
+
+app.get('/', async (c) => {
+  const user = getAuthUser(c);
+  const link = await findLinkInvolving(user.id);
+  if (!link) return c.json({ data: null });
+
+  const data = await toPartnerLinkResponse(link, user.id);
+  return c.json({ data });
+});
+
+app.post('/invite', async (c) => {
+  const user = getAuthUser(c);
+  const payload = (await c.req.json()) as { email?: unknown };
+  const email = typeof payload.email === 'string' ? payload.email.toLowerCase().trim() : '';
+
+  if (!email || !EMAIL_PATTERN.test(email)) {
+    return c.json({ error: 'Enter a valid email address' }, HTTP_STATUS.BAD_REQUEST);
+  }
+
+  let result;
+  try {
+    result = await db.transaction(async (tx) => {
+      const [target] = await tx.select({ id: users.id }).from(users).where(eq(users.email, email));
+      if (!target) {
+        return { error: 'No Quro account with that email', status: HTTP_STATUS.NOT_FOUND } as const;
+      }
+      if (target.id === user.id) {
+        return { error: 'You cannot invite yourself', status: HTTP_STATUS.BAD_REQUEST } as const;
+      }
+
+      const [existing] = await tx
+        .select({ requesterId: partnerLinks.requesterId })
+        .from(partnerLinks)
+        .where(or(linkInvolving(user.id), linkInvolving(target.id)));
+      if (existing) {
+        const error =
+          existing.requesterId === user.id || existing.requesterId === target.id
+            ? 'A partner link already exists'
+            : 'That user already has a partner link';
+        return { error, status: HTTP_STATUS.CONFLICT } as const;
+      }
+
+      const [link] = await tx
+        .insert(partnerLinks)
+        .values({ requesterId: user.id, addresseeId: target.id })
+        .returning();
+      return { link } as const;
+    });
+  } catch (error) {
+    // A concurrent invite can slip past the existence check at read-committed
+    // isolation; the unique indexes reject it, which is a conflict, not a 500.
+    if (isUniqueViolation(error)) {
+      return c.json({ error: 'A partner link already exists' }, HTTP_STATUS.CONFLICT);
+    }
+    throw error;
+  }
+
+  if ('error' in result) {
+    return c.json({ error: result.error }, result.status);
+  }
+
+  const data = await toPartnerLinkResponse(result.link, user.id);
+  return c.json({ data }, HTTP_STATUS.CREATED);
+});
+
+app.post('/accept', async (c) => {
+  const user = getAuthUser(c);
+  const [link] = await db
+    .update(partnerLinks)
+    .set({ status: 'accepted', respondedAt: new Date() })
+    .where(and(eq(partnerLinks.addresseeId, user.id), eq(partnerLinks.status, 'pending')))
+    .returning();
+
+  if (!link) {
+    return c.json({ error: 'No pending invitation found' }, HTTP_STATUS.NOT_FOUND);
+  }
+
+  const data = await toPartnerLinkResponse(link, user.id);
+  return c.json({ data });
+});
+
+app.post('/decline', async (c) => {
+  const user = getAuthUser(c);
+  const [link] = await db
+    .delete(partnerLinks)
+    .where(and(eq(partnerLinks.addresseeId, user.id), eq(partnerLinks.status, 'pending')))
+    .returning();
+
+  if (!link) {
+    return c.json({ error: 'No pending invitation found' }, HTTP_STATUS.NOT_FOUND);
+  }
+
+  return c.json({ data: null });
+});
+
+app.delete('/', async (c) => {
+  const user = getAuthUser(c);
+
+  const removed = await db.transaction(async (tx) => {
+    const [link] = await tx.select().from(partnerLinks).where(linkInvolving(user.id));
+    if (!link) return false;
+
+    if (link.status === 'accepted') {
+      const memberIds = [link.requesterId, link.addresseeId];
+      await tx
+        .update(savingsAccounts)
+        .set({ isJoint: false })
+        .where(and(inArray(savingsAccounts.userId, memberIds), eq(savingsAccounts.isJoint, true)));
+      await tx
+        .update(properties)
+        .set({ isJoint: false })
+        .where(and(inArray(properties.userId, memberIds), eq(properties.isJoint, true)));
+      await tx
+        .update(mortgages)
+        .set({ isJoint: false })
+        .where(and(inArray(mortgages.userId, memberIds), eq(mortgages.isJoint, true)));
+    }
+
+    await tx.delete(partnerLinks).where(eq(partnerLinks.id, link.id));
+    return true;
+  });
+
+  if (!removed) {
+    return c.json({ error: 'No partner link found' }, HTTP_STATUS.NOT_FOUND);
+  }
+
+  return c.json({ data: null });
+});
+
+export default app;

--- a/packages/backend/src/routes/savings.ts
+++ b/packages/backend/src/routes/savings.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, getTableColumns, isNull } from 'drizzle-orm';
 import { Hono } from 'hono';
 import {
   SAVINGS_ACCOUNT_TYPES,
@@ -10,6 +10,7 @@ import { HTTP_STATUS } from '../constants/http';
 import { db } from '../db/client';
 import { savingsAccounts, savingsTransactions } from '../db/schema';
 import { getAuthUser } from '../lib/authUser';
+import { assertJointAllowed, getAcceptedPartnerId, ownedOrJointPredicate } from '../lib/partner';
 import {
   toFiniteNumber,
   toSignedSavingsAmount,
@@ -18,6 +19,7 @@ import {
 import {
   err,
   ok,
+  parseBooleanField,
   parseCurrencyField,
   parseDateField,
   parseId,
@@ -45,6 +47,7 @@ const SAVINGS_ACCOUNT_FIELDS = [
   'accountType',
   'color',
   'emoji',
+  'isJoint',
 ] as const;
 const SAVINGS_TRANSACTION_FIELDS = ['accountId', 'type', 'amount', 'date', 'note'] as const;
 
@@ -57,6 +60,7 @@ type SavingsAccountPayload = {
   accountType: SavingsAccountType;
   color: string;
   emoji: string;
+  isJoint: boolean;
 };
 
 type SavingsTransactionPayload = {
@@ -97,6 +101,8 @@ const savingsAccountParsers: FieldParsers<SavingsAccountPayload> = {
   accountType: parseSavingsAccountTypeField,
   color: (value) => parseTextField(value, 'Color is required'),
   emoji: (value) => parseTextField(value, 'Emoji is required'),
+  isJoint: (value) =>
+    value === undefined ? ok(false) : parseBooleanField(value, 'isJoint must be a boolean'),
 };
 
 const savingsTransactionParsers: FieldParsers<SavingsTransactionPayload> = {
@@ -166,6 +172,7 @@ function toSavingsAccountInsertValues(
     accountType: payload.accountType,
     color: payload.color,
     emoji: payload.emoji,
+    isJoint: payload.isJoint,
   };
 }
 
@@ -181,6 +188,7 @@ function toSavingsAccountUpdateValues(
     accountType: payload.accountType,
     color: payload.color,
     emoji: payload.emoji,
+    isJoint: payload.isJoint,
   };
 }
 
@@ -213,36 +221,50 @@ function toSavingsTransactionUpdateValues(
 function getSavingsAccountPredicate(
   accountId: number,
   userId: number,
+  partnerId: number | null,
   options: { includeArchived?: boolean } = {},
 ) {
-  const basePredicate = and(eq(savingsAccounts.id, accountId), eq(savingsAccounts.userId, userId));
+  const basePredicate = and(
+    eq(savingsAccounts.id, accountId),
+    ownedOrJointPredicate(savingsAccounts, userId, partnerId),
+  );
   return options.includeArchived
     ? basePredicate
     : and(basePredicate, isNull(savingsAccounts.archivedAt));
 }
 
-async function getOwnedSavingsAccount(
+async function getAccessibleSavingsAccount(
   accountId: number,
   userId: number,
+  partnerId: number | null,
   options: { includeArchived?: boolean } = {},
 ) {
   const [account] = await db
     .select()
     .from(savingsAccounts)
-    .where(getSavingsAccountPredicate(accountId, userId, options));
+    .where(getSavingsAccountPredicate(accountId, userId, partnerId, options));
   return account ?? null;
 }
 
-async function getOwnedSavingsTransaction(transactionId: number, userId: number) {
+async function getAccessibleSavingsTransaction(
+  transactionId: number,
+  userId: number,
+  partnerId: number | null,
+) {
   const [transaction] = await db
-    .select()
+    .select(getTableColumns(savingsTransactions))
     .from(savingsTransactions)
-    .where(and(eq(savingsTransactions.id, transactionId), eq(savingsTransactions.userId, userId)));
+    .innerJoin(savingsAccounts, eq(savingsTransactions.accountId, savingsAccounts.id))
+    .where(
+      and(
+        eq(savingsTransactions.id, transactionId),
+        ownedOrJointPredicate(savingsAccounts, userId, partnerId),
+      ),
+    );
   return transaction ?? null;
 }
 
 async function syncSavingsBalancesForEditedTransaction(params: {
-  userId: number;
   previousAccountId: number;
   nextAccountId: number;
   previousType: unknown;
@@ -256,18 +278,13 @@ async function syncSavingsBalancesForEditedTransaction(params: {
   if (params.nextAccountId === params.previousAccountId) {
     await updateSavingsAccountBalanceByDelta(
       params.previousAccountId,
-      params.userId,
       newSignedAmount - oldSignedAmount,
     );
     return;
   }
 
-  await updateSavingsAccountBalanceByDelta(
-    params.previousAccountId,
-    params.userId,
-    -oldSignedAmount,
-  );
-  await updateSavingsAccountBalanceByDelta(params.nextAccountId, params.userId, newSignedAmount);
+  await updateSavingsAccountBalanceByDelta(params.previousAccountId, -oldSignedAmount);
+  await updateSavingsAccountBalanceByDelta(params.nextAccountId, newSignedAmount);
 }
 
 function resolveNextSavingsTransactionState(
@@ -281,28 +298,66 @@ function resolveNextSavingsTransactionState(
   };
 }
 
-async function validatePatchedSavingsTransactionAccount(params: {
+type EditableTransactionResult =
+  | { ok: true; transaction: typeof savingsTransactions.$inferSelect }
+  | { ok: false; error: string; status: 400 | 404 };
+
+async function getEditableSavingsTransaction(
+  transactionId: number,
+  userId: number,
+  partnerId: number | null,
+  action: 'modify' | 'delete',
+): Promise<EditableTransactionResult> {
+  const transaction = await getAccessibleSavingsTransaction(transactionId, userId, partnerId);
+  if (!transaction) {
+    return { ok: false, error: 'Transaction not found', status: HTTP_STATUS.NOT_FOUND };
+  }
+
+  const account = await getAccessibleSavingsAccount(transaction.accountId, userId, partnerId, {
+    includeArchived: true,
+  });
+  if (account?.bunqAccountId) {
+    const verb = action === 'modify' ? 'modify transactions on' : 'delete transactions from';
+    return {
+      ok: false,
+      error: `Cannot ${verb} a Bunq-synced account`,
+      status: HTTP_STATUS.BAD_REQUEST,
+    };
+  }
+
+  return { ok: true, transaction };
+}
+
+async function resolvePatchedSavingsTransactionAccount(params: {
   userId: number;
+  partnerId: number | null;
   previousAccountId: number;
   nextAccountId: number;
-}): Promise<string | null> {
-  if (params.nextAccountId === params.previousAccountId) return null;
-  const account = await getOwnedSavingsAccount(params.nextAccountId, params.userId);
-  return account ? null : 'Account not found';
+}): Promise<{ ok: true; nextAccountUserId: number | null } | { ok: false; error: string }> {
+  if (params.nextAccountId === params.previousAccountId) {
+    return { ok: true, nextAccountUserId: null };
+  }
+  const account = await getAccessibleSavingsAccount(
+    params.nextAccountId,
+    params.userId,
+    params.partnerId,
+  );
+  if (!account) return { ok: false, error: 'Account not found' };
+  return { ok: true, nextAccountUserId: account.userId };
 }
 
 // ── Accounts ─────────────────────────────────────────────────────────────────
 
 app.get('/accounts', async (c) => {
   const user = getAuthUser(c);
+  const partnerId = await getAcceptedPartnerId(user.id);
   const includeArchived = c.req.query('includeArchived') === 'true';
+  const accessPredicate = ownedOrJointPredicate(savingsAccounts, user.id, partnerId);
   const data = await db
     .select()
     .from(savingsAccounts)
     .where(
-      includeArchived
-        ? eq(savingsAccounts.userId, user.id)
-        : and(eq(savingsAccounts.userId, user.id), isNull(savingsAccounts.archivedAt)),
+      includeArchived ? accessPredicate : and(accessPredicate, isNull(savingsAccounts.archivedAt)),
     );
   return c.json({ data });
 });
@@ -312,7 +367,8 @@ app.get('/accounts/:id', async (c) => {
   const id = parseId(c.req.param('id'));
   if (id === null) return c.json({ error: 'Invalid account id' }, HTTP_STATUS.BAD_REQUEST);
 
-  const data = await getOwnedSavingsAccount(id, user.id);
+  const partnerId = await getAcceptedPartnerId(user.id);
+  const data = await getAccessibleSavingsAccount(id, user.id, partnerId);
   if (!data) return c.json({ error: 'Account not found' }, HTTP_STATUS.NOT_FOUND);
   return c.json({ data });
 });
@@ -324,6 +380,9 @@ app.post('/accounts', async (c) => {
 
   const body = parseSavingsAccountCreate(rawBody.value);
   if (!body.ok) return c.json({ error: body.error }, HTTP_STATUS.BAD_REQUEST);
+
+  const jointError = await assertJointAllowed(user.id, body.value.isJoint);
+  if (jointError) return c.json({ error: jointError }, HTTP_STATUS.BAD_REQUEST);
 
   const [data] = await db
     .insert(savingsAccounts)
@@ -346,10 +405,14 @@ app.patch('/accounts/:id', async (c) => {
     return c.json({ error: 'No savings account fields provided' }, HTTP_STATUS.BAD_REQUEST);
   }
 
+  const jointError = await assertJointAllowed(user.id, body.value.isJoint);
+  if (jointError) return c.json({ error: jointError }, HTTP_STATUS.BAD_REQUEST);
+
+  const partnerId = await getAcceptedPartnerId(user.id);
   const [data] = await db
     .update(savingsAccounts)
     .set(toSavingsAccountUpdateValues(body.value))
-    .where(getSavingsAccountPredicate(id, user.id))
+    .where(getSavingsAccountPredicate(id, user.id, partnerId))
     .returning();
   if (!data) return c.json({ error: 'Account not found' }, HTTP_STATUS.NOT_FOUND);
   return c.json({ data });
@@ -360,10 +423,11 @@ app.delete('/accounts/:id', async (c) => {
   const id = parseId(c.req.param('id'));
   if (id === null) return c.json({ error: 'Invalid account id' }, HTTP_STATUS.BAD_REQUEST);
 
+  const partnerId = await getAcceptedPartnerId(user.id);
   if (c.req.query('cascade') === 'true') {
     const [data] = await db
       .delete(savingsAccounts)
-      .where(getSavingsAccountPredicate(id, user.id, { includeArchived: true }))
+      .where(getSavingsAccountPredicate(id, user.id, partnerId, { includeArchived: true }))
       .returning();
     if (!data) return c.json({ error: 'Account not found' }, HTTP_STATUS.NOT_FOUND);
     return c.json({ data });
@@ -372,7 +436,7 @@ app.delete('/accounts/:id', async (c) => {
   const [data] = await db
     .update(savingsAccounts)
     .set({ archivedAt: new Date() })
-    .where(getSavingsAccountPredicate(id, user.id))
+    .where(getSavingsAccountPredicate(id, user.id, partnerId))
     .returning();
   if (!data) return c.json({ error: 'Account not found' }, HTTP_STATUS.NOT_FOUND);
   return c.json({ data });
@@ -383,10 +447,11 @@ app.post('/accounts/:id/unarchive', async (c) => {
   const id = parseId(c.req.param('id'));
   if (id === null) return c.json({ error: 'Invalid account id' }, HTTP_STATUS.BAD_REQUEST);
 
+  const partnerId = await getAcceptedPartnerId(user.id);
   const [data] = await db
     .update(savingsAccounts)
     .set({ archivedAt: null })
-    .where(and(eq(savingsAccounts.id, id), eq(savingsAccounts.userId, user.id)))
+    .where(getSavingsAccountPredicate(id, user.id, partnerId, { includeArchived: true }))
     .returning();
   if (!data) return c.json({ error: 'Account not found' }, HTTP_STATUS.NOT_FOUND);
   return c.json({ data });
@@ -396,28 +461,29 @@ app.post('/accounts/:id/unarchive', async (c) => {
 
 app.get('/transactions', async (c) => {
   const user = getAuthUser(c);
+  const partnerId = await getAcceptedPartnerId(user.id);
   const accountId = c.req.query('accountId');
   if (accountId) {
     const parsedAccountId = parseId(accountId);
     if (parsedAccountId === null) {
       return c.json({ error: 'Invalid account id' }, HTTP_STATUS.BAD_REQUEST);
     }
+    const account = await getAccessibleSavingsAccount(parsedAccountId, user.id, partnerId, {
+      includeArchived: true,
+    });
+    if (!account) return c.json({ error: 'Account not found' }, HTTP_STATUS.NOT_FOUND);
     const data = await db
       .select()
       .from(savingsTransactions)
-      .where(
-        and(
-          eq(savingsTransactions.accountId, parsedAccountId),
-          eq(savingsTransactions.userId, user.id),
-        ),
-      );
+      .where(eq(savingsTransactions.accountId, parsedAccountId));
     return c.json({ data });
   }
 
   const data = await db
-    .select()
+    .select(getTableColumns(savingsTransactions))
     .from(savingsTransactions)
-    .where(eq(savingsTransactions.userId, user.id));
+    .innerJoin(savingsAccounts, eq(savingsTransactions.accountId, savingsAccounts.id))
+    .where(ownedOrJointPredicate(savingsAccounts, user.id, partnerId));
   return c.json({ data });
 });
 
@@ -426,7 +492,8 @@ app.get('/transactions/:id', async (c) => {
   const id = parseId(c.req.param('id'));
   if (id === null) return c.json({ error: 'Invalid transaction id' }, HTTP_STATUS.BAD_REQUEST);
 
-  const data = await getOwnedSavingsTransaction(id, user.id);
+  const partnerId = await getAcceptedPartnerId(user.id);
+  const data = await getAccessibleSavingsTransaction(id, user.id, partnerId);
   if (!data) return c.json({ error: 'Transaction not found' }, HTTP_STATUS.NOT_FOUND);
   return c.json({ data });
 });
@@ -439,7 +506,8 @@ app.post('/transactions', async (c) => {
   const body = parseSavingsTransactionCreate(rawBody.value);
   if (!body.ok) return c.json({ error: body.error }, HTTP_STATUS.BAD_REQUEST);
 
-  const account = await getOwnedSavingsAccount(body.value.accountId, user.id);
+  const partnerId = await getAcceptedPartnerId(user.id);
+  const account = await getAccessibleSavingsAccount(body.value.accountId, user.id, partnerId);
   if (!account) return c.json({ error: 'Account not found' }, HTTP_STATUS.NOT_FOUND);
   if (account.bunqAccountId) {
     return c.json(
@@ -450,12 +518,11 @@ app.post('/transactions', async (c) => {
 
   const [data] = await db
     .insert(savingsTransactions)
-    .values(toSavingsTransactionInsertValues(body.value, user.id))
+    .values(toSavingsTransactionInsertValues(body.value, account.userId ?? user.id))
     .returning();
 
   await updateSavingsAccountBalanceByDelta(
     body.value.accountId,
-    user.id,
     toSignedSavingsAmount(body.value.type, body.value.amount),
   );
 
@@ -476,38 +543,36 @@ app.patch('/transactions/:id', async (c) => {
     return c.json({ error: 'No savings transaction fields provided' }, HTTP_STATUS.BAD_REQUEST);
   }
 
-  const existing = await getOwnedSavingsTransaction(id, user.id);
-  if (!existing) return c.json({ error: 'Transaction not found' }, HTTP_STATUS.NOT_FOUND);
-
-  const existingAccount = await getOwnedSavingsAccount(existing.accountId, user.id, {
-    includeArchived: true,
-  });
-  if (existingAccount?.bunqAccountId) {
-    return c.json(
-      { error: 'Cannot modify transactions on a Bunq-synced account' },
-      HTTP_STATUS.BAD_REQUEST,
-    );
-  }
+  const partnerId = await getAcceptedPartnerId(user.id);
+  const editable = await getEditableSavingsTransaction(id, user.id, partnerId, 'modify');
+  if (!editable.ok) return c.json({ error: editable.error }, editable.status);
+  const existing = editable.transaction;
 
   const nextState = resolveNextSavingsTransactionState(body.value, existing);
-  const accountValidationError = await validatePatchedSavingsTransactionAccount({
+  const nextAccount = await resolvePatchedSavingsTransactionAccount({
     userId: user.id,
+    partnerId,
     previousAccountId: existing.accountId,
     nextAccountId: nextState.accountId,
   });
-  if (accountValidationError) {
-    return c.json({ error: accountValidationError }, HTTP_STATUS.NOT_FOUND);
+  if (!nextAccount.ok) {
+    return c.json({ error: nextAccount.error }, HTTP_STATUS.NOT_FOUND);
+  }
+
+  const updateValues = toSavingsTransactionUpdateValues(body.value);
+  // Keep the row's userId aligned with its (possibly new) parent account owner.
+  if (nextAccount.nextAccountUserId !== null) {
+    updateValues.userId = nextAccount.nextAccountUserId;
   }
 
   const [data] = await db
     .update(savingsTransactions)
-    .set(toSavingsTransactionUpdateValues(body.value))
-    .where(and(eq(savingsTransactions.id, id), eq(savingsTransactions.userId, user.id)))
+    .set(updateValues)
+    .where(eq(savingsTransactions.id, id))
     .returning();
   if (!data) return c.json({ error: 'Transaction not found' }, HTTP_STATUS.NOT_FOUND);
 
   await syncSavingsBalancesForEditedTransaction({
-    userId: user.id,
     previousAccountId: existing.accountId,
     nextAccountId: nextState.accountId,
     previousType: existing.type,
@@ -524,28 +589,18 @@ app.delete('/transactions/:id', async (c) => {
   const id = parseId(c.req.param('id'));
   if (id === null) return c.json({ error: 'Invalid transaction id' }, HTTP_STATUS.BAD_REQUEST);
 
-  const toDelete = await getOwnedSavingsTransaction(id, user.id);
-  if (!toDelete) return c.json({ error: 'Transaction not found' }, HTTP_STATUS.NOT_FOUND);
-
-  const deleteAccount = await getOwnedSavingsAccount(toDelete.accountId, user.id, {
-    includeArchived: true,
-  });
-  if (deleteAccount?.bunqAccountId) {
-    return c.json(
-      { error: 'Cannot delete transactions from a Bunq-synced account' },
-      HTTP_STATUS.BAD_REQUEST,
-    );
-  }
+  const partnerId = await getAcceptedPartnerId(user.id);
+  const editable = await getEditableSavingsTransaction(id, user.id, partnerId, 'delete');
+  if (!editable.ok) return c.json({ error: editable.error }, editable.status);
 
   const [data] = await db
     .delete(savingsTransactions)
-    .where(and(eq(savingsTransactions.id, id), eq(savingsTransactions.userId, user.id)))
+    .where(eq(savingsTransactions.id, id))
     .returning();
   if (!data) return c.json({ error: 'Transaction not found' }, HTTP_STATUS.NOT_FOUND);
 
   await updateSavingsAccountBalanceByDelta(
     data.accountId,
-    user.id,
     -toSignedSavingsAmount(data.type, data.amount),
   );
 

--- a/packages/backend/src/test/integration.ts
+++ b/packages/backend/src/test/integration.ts
@@ -1,4 +1,4 @@
-import { like, inArray } from 'drizzle-orm';
+import { like, inArray, or } from 'drizzle-orm';
 import { app } from '../index';
 import { db } from '../db/client';
 import {
@@ -11,6 +11,7 @@ import {
   holdings,
   mortgageTransactions,
   mortgages,
+  partnerLinks,
   payslips,
   pensionPots,
   pensionTransactions,
@@ -172,6 +173,11 @@ async function cleanupTestUsers(emailPattern: string) {
   await db.delete(budgetCategories).where(inArray(budgetCategories.userId, userIds));
   await db.delete(categoryMappings).where(inArray(categoryMappings.userId, userIds));
   await db.delete(goals).where(inArray(goals.userId, userIds));
+  await db
+    .delete(partnerLinks)
+    .where(
+      or(inArray(partnerLinks.requesterId, userIds), inArray(partnerLinks.addresseeId, userIds)),
+    );
   await db.delete(sessions).where(inArray(sessions.userId, userIds));
   await db.delete(users).where(inArray(users.id, userIds));
 }

--- a/packages/frontend/src/features/dashboard/components/RecentTransactionsCard.tsx
+++ b/packages/frontend/src/features/dashboard/components/RecentTransactionsCard.tsx
@@ -1,5 +1,6 @@
 import { ArrowRight, CreditCard } from 'lucide-react';
 import { Link } from 'react-router';
+import { JointBadge } from '@/features/partner';
 import type { DashboardFormatFn, DashboardTransaction } from '../types';
 
 const txIconClass = (type: string) => {
@@ -24,7 +25,10 @@ function TransactionItem({
           <CreditCard size={15} />
         </div>
         <div>
-          <p className="text-sm font-medium text-slate-800">{tx.name}</p>
+          <div className="flex items-center gap-1.5">
+            <p className="text-sm font-medium text-slate-800">{tx.name}</p>
+            <JointBadge isJoint={tx.isJoint} size="xs" />
+          </div>
           <p className="text-xs text-slate-400">
             {tx.category} · {tx.date}
           </p>

--- a/packages/frontend/src/features/dashboard/types.ts
+++ b/packages/frontend/src/features/dashboard/types.ts
@@ -10,6 +10,7 @@ export type DashboardTransaction = {
   date: string;
   type: string;
   amount: number;
+  isJoint: boolean;
 };
 
 export type AllocationItem = {

--- a/packages/frontend/src/features/dashboard/utils/dashboard-data.test.ts
+++ b/packages/frontend/src/features/dashboard/utils/dashboard-data.test.ts
@@ -82,6 +82,7 @@ test('normalizes dashboard payload rows using each row currency metadata', () =>
       date: '2026-03-05',
       category: 'Investment',
       currency: 'GBP',
+      isJoint: false,
     },
     {
       id: 2,
@@ -91,6 +92,7 @@ test('normalizes dashboard payload rows using each row currency metadata', () =>
       date: '2026-03-06',
       category: 'Property',
       currency: 'USD',
+      isJoint: false,
     },
   ];
 
@@ -120,6 +122,7 @@ test('computes dashboard stats from normalized mixed-currency activity and paysl
         date: `${currentMonthKey}-05`,
         category: 'Salary',
         currency: 'USD',
+        isJoint: false,
       },
       {
         id: 2,
@@ -129,6 +132,7 @@ test('computes dashboard stats from normalized mixed-currency activity and paysl
         date: `${currentMonthKey}-07`,
         category: 'Budget',
         currency: 'GBP',
+        isJoint: false,
       },
       {
         id: 3,
@@ -138,6 +142,7 @@ test('computes dashboard stats from normalized mixed-currency activity and paysl
         date: `${currentMonthKey}-09`,
         category: 'Savings',
         currency: 'USD',
+        isJoint: false,
       },
     ] satisfies DashboardTransactionPayload[],
     convertToEur,
@@ -165,4 +170,54 @@ test('computes dashboard stats from normalized mixed-currency activity and paysl
   expect(stats.monthlyCategoryChange('Savings')).toBeCloseTo(46.1, 10);
   expect(stats.monthlySalaryValue).toBeCloseTo((2300 + 200) * 1.18, 10);
   expect(stats.salaryTrendChange).toBe(0);
+});
+
+test('halves joint transactions in monthly stats but keeps full display amounts', () => {
+  const convertToEur = createConvertToBase('EUR');
+  const currentMonthKey = toMonthKey(new Date());
+  const transactions = normalizeDashboardTransactions(
+    [
+      {
+        id: 1,
+        name: 'Joint savings deposit',
+        type: 'transfer',
+        amount: -500,
+        date: `${currentMonthKey}-04`,
+        category: 'Savings',
+        currency: 'EUR',
+        isJoint: true,
+      },
+      {
+        id: 2,
+        name: 'Personal savings deposit',
+        type: 'transfer',
+        amount: -200,
+        date: `${currentMonthKey}-05`,
+        category: 'Savings',
+        currency: 'EUR',
+        isJoint: false,
+      },
+      {
+        id: 3,
+        name: 'Joint rent income',
+        type: 'income',
+        amount: 1000,
+        date: `${currentMonthKey}-06`,
+        category: 'Property',
+        currency: 'EUR',
+        isJoint: true,
+      },
+    ] satisfies DashboardTransactionPayload[],
+    convertToEur,
+  );
+
+  // Display rows keep the full amount; only aggregates are weighted.
+  expect(transactions[0]?.amount).toBe(-500);
+  expect(transactions[0]?.isJoint).toBe(true);
+
+  const stats = computeDashboardTxnStats(transactions, [], convertToEur);
+
+  expect(stats.totalSavingsDeposited).toBe(500 / 2 + 200);
+  expect(stats.totalIncome).toBe(1000 / 2);
+  expect(stats.monthlyCategoryChange('Savings')).toBe(500 / 2 + 200);
 });

--- a/packages/frontend/src/features/dashboard/utils/dashboard-data.ts
+++ b/packages/frontend/src/features/dashboard/utils/dashboard-data.ts
@@ -156,6 +156,7 @@ export function normalizeDashboardTransactions(
     date: transaction.date,
     type: transaction.type,
     amount: convertToBase(transaction.amount, transaction.currency),
+    isJoint: transaction.isJoint ?? false,
   }));
 }
 
@@ -266,6 +267,14 @@ export const buildMonthlySummaryItems = (
   },
 ];
 
+const JOINT_TXN_WEIGHT = 0.5;
+
+// Joint-account transactions count half in the monthly summary so the two
+// partners' summaries add up to the real totals. Display rows keep the full
+// amount; only these aggregates are weighted.
+const weightedTxnAmount = (tx: DashboardTransaction): number =>
+  tx.isJoint ? tx.amount * JOINT_TXN_WEIGHT : tx.amount;
+
 export function computeDashboardTxnStats(
   transactions: readonly DashboardTransaction[],
   payslips: readonly Payslip[],
@@ -276,17 +285,21 @@ export function computeDashboardTxnStats(
   const monthlyCategoryChange = (category: string) =>
     monthTxns
       .filter((tx) => tx.category === category)
-      .reduce((sum, tx) => sum + (tx.type === 'transfer' ? -tx.amount : tx.amount), 0);
+      .reduce(
+        (sum, tx) =>
+          sum + (tx.type === 'transfer' ? -weightedTxnAmount(tx) : weightedTxnAmount(tx)),
+        0,
+      );
   const { monthlySalaryValue, salaryTrendChange } = computeSalaryMetrics(payslips, convertToBase);
   const totalIncome = monthTxns
     .filter((tx) => tx.type === 'income')
-    .reduce((s, tx) => s + Math.abs(tx.amount), 0);
+    .reduce((s, tx) => s + Math.abs(weightedTxnAmount(tx)), 0);
   const totalExpenses = monthTxns
     .filter((tx) => tx.type === 'expense')
-    .reduce((s, tx) => s + Math.abs(tx.amount), 0);
+    .reduce((s, tx) => s + Math.abs(weightedTxnAmount(tx)), 0);
   const totalSavingsDeposited = monthTxns
     .filter((tx) => tx.type === 'transfer' && tx.category === 'Savings')
-    .reduce((s, tx) => s - tx.amount, 0);
+    .reduce((s, tx) => s - weightedTxnAmount(tx), 0);
   return {
     monthlyCategoryChange,
     monthlySalaryValue,

--- a/packages/frontend/src/features/investments/components/AddPropertyModal.tsx
+++ b/packages/frontend/src/features/investments/components/AddPropertyModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { CURRENCY_CODES, type CurrencyCode, useCurrency } from '@/lib/CurrencyContext';
 import { Modal, ModalFooter, FormField, SelectInput, TextInput } from '@/components/ui';
+import { JointToggleField } from '@/features/partner';
 import type { Property } from '@quro/shared';
 
 const PROPERTY_TYPES = [
@@ -62,12 +63,13 @@ type PropertyFormState = {
   purchasePrice: string;
   currentValue: string;
   monthlyRent: string;
+  isJoint: boolean;
 };
 
 type PropertyFormFieldsProps = {
   form: PropertyFormState;
   errors: Record<string, string>;
-  onSet: (field: string, value: string) => void;
+  onSet: (field: string, value: string | boolean) => void;
 };
 
 function PropertyIdentityFields({ form, errors, onSet }: PropertyFormFieldsProps) {
@@ -157,6 +159,11 @@ function PropertyFormFields({ form, errors, onSet }: PropertyFormFieldsProps) {
     <>
       <PropertyIdentityFields form={form} errors={errors} onSet={onSet} />
       <PropertyValueFields form={form} errors={errors} onSet={onSet} />
+      <JointToggleField
+        checked={form.isJoint}
+        onChange={(checked) => onSet('isJoint', checked)}
+        hint="Also applies to a linked mortgage. Counts 50/50 in both dashboards."
+      />
     </>
   );
 }
@@ -181,10 +188,11 @@ function useAddPropertyForm() {
     purchasePrice: '',
     currentValue: '',
     monthlyRent: '',
+    isJoint: false,
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
 
-  function set(field: string, value: string): void {
+  function set(field: string, value: string | boolean): void {
     setForm((previous) => ({ ...previous, [field]: value }));
     if (errors[field]) {
       setErrors((previous) => {
@@ -224,6 +232,7 @@ export function AddPropertyModal({ onClose, onSave }: AddPropertyModalProps) {
       mortgage: 0,
       mortgageId: null,
       monthlyRent: parsed.monthlyRent,
+      isJoint: form.isJoint,
     });
     onClose();
   }

--- a/packages/frontend/src/features/investments/components/PropertyTab.tsx
+++ b/packages/frontend/src/features/investments/components/PropertyTab.tsx
@@ -1,6 +1,7 @@
 import { Building2, ChevronDown, ChevronUp, Edit3, ExternalLink, Home, Plus } from 'lucide-react';
 import { Link } from 'react-router';
 import { EmptyState } from '@/components/ui';
+import { JointBadge } from '@/features/partner';
 import type { Mortgage, Property, PropertyTransaction } from '@quro/shared';
 import { getPropertyMortgageBalance } from '../utils/position';
 import { PropertyTxnHistory } from './PropertyTxnHistory';
@@ -302,6 +303,7 @@ function PropertyCardHeader({
         <div className="min-w-0">
           <p className="font-semibold text-slate-900 truncate">{property.address}</p>
           <div className="flex items-center gap-2 mt-0.5 flex-wrap">
+            <JointBadge isJoint={property.isJoint} ownerUserId={property.userId} size="xs" />
             <span className="text-[10px] bg-slate-100 text-slate-600 px-2 py-0.5 rounded-full font-medium">
               {property.propertyType}
             </span>

--- a/packages/frontend/src/features/investments/components/UpdatePropertyModal.tsx
+++ b/packages/frontend/src/features/investments/components/UpdatePropertyModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useCurrency } from '@/lib/CurrencyContext';
 import { Modal, ModalFooter, FormField, TextInput } from '@/components/ui';
+import { JointToggleField } from '@/features/partner';
 import { formatFixedInputValue } from '@/lib/utils';
 import type { Property } from '@quro/shared';
 
@@ -8,7 +9,7 @@ type UpdatePropertyModalProps = {
   property: Property;
   mortgageBalance: number;
   onClose: () => void;
-  onSave: (id: number, value: number, rent: number) => void;
+  onSave: (id: number, value: number, rent: number, isJoint: boolean) => void;
 };
 
 type PropertyStatsPreviewProps = {
@@ -51,6 +52,7 @@ function PropertyStatsPreview({
 function useUpdatePropertyForm(property: Property) {
   const [value, setValue] = useState(formatFixedInputValue(property.currentValue));
   const [rent, setRent] = useState(formatFixedInputValue(property.monthlyRent));
+  const [isJoint, setIsJoint] = useState(property.isJoint);
   const [errors, setErrors] = useState<Record<string, string>>({});
 
   const numericValue = parseFloat(value) || 0;
@@ -67,12 +69,14 @@ function useUpdatePropertyForm(property: Property) {
   return {
     value,
     rent,
+    isJoint,
     errors,
     numericValue,
     equity,
     appreciation,
     appreciationPct,
     setRent,
+    setIsJoint,
     setErrors,
     handleValueChange,
   };
@@ -100,7 +104,7 @@ function MortgageBalanceField({ mortgageBalance, currency, fmtNative }: Mortgage
 function buildUpdateSaveHandler(
   form: ReturnType<typeof useUpdatePropertyForm>,
   property: Property,
-  onSave: (id: number, value: number, rent: number) => void,
+  onSave: (id: number, value: number, rent: number, isJoint: boolean) => void,
   onClose: () => void,
 ) {
   return () => {
@@ -108,7 +112,7 @@ function buildUpdateSaveHandler(
       form.setErrors({ value: 'Required' });
       return;
     }
-    onSave(property.id, form.numericValue, parseFloat(form.rent) || 0);
+    onSave(property.id, form.numericValue, parseFloat(form.rent) || 0, form.isJoint);
     onClose();
   };
 }
@@ -159,6 +163,11 @@ export function UpdatePropertyModal({
           onChange={form.setRent}
         />
       </FormField>
+      <JointToggleField
+        checked={form.isJoint}
+        onChange={form.setIsJoint}
+        hint="Also applies to a linked mortgage. Counts 50/50 in both dashboards."
+      />
       <PropertyStatsPreview
         equity={equity}
         appreciation={form.appreciation}

--- a/packages/frontend/src/features/investments/hooks/useInvestmentActions.ts
+++ b/packages/frontend/src/features/investments/hooks/useInvestmentActions.ts
@@ -85,9 +85,11 @@ export function useInvestmentActions(
     handleAddHoldingTxn: (transaction) =>
       mutateTransaction(transaction, updateHoldingTxn.mutate, createHoldingTxn.mutate),
     handleDeleteHoldingTxn: (id: number) => deleteHoldingTxn.mutate(id),
-    handleUpdateProperty: (id: number, value: number, rent: number) => {
+    handleUpdateProperty: (id: number, value: number, rent: number, isJoint: boolean) => {
       const existing = properties.find((property) => property.id === id);
-      if (existing) updateProperty.mutate({ ...existing, currentValue: value, monthlyRent: rent });
+      if (existing) {
+        updateProperty.mutate({ ...existing, currentValue: value, monthlyRent: rent, isJoint });
+      }
     },
     handleSaveProperty: (property) => {
       createProperty.mutate(property);

--- a/packages/frontend/src/features/investments/types.ts
+++ b/packages/frontend/src/features/investments/types.ts
@@ -91,7 +91,7 @@ export type InvestmentActions = {
   handleDeleteHolding: (id: number, mode?: 'preserveTransactions' | 'deleteTransactions') => void;
   handleAddHoldingTxn: (transaction: SaveHoldingTxnInput) => void;
   handleDeleteHoldingTxn: (id: number) => void;
-  handleUpdateProperty: (id: number, value: number, rent: number) => void;
+  handleUpdateProperty: (id: number, value: number, rent: number, isJoint: boolean) => void;
   handleSaveProperty: (property: Omit<Property, 'id'>) => void;
   handleAddPropertyTxn: (transaction: SavePropertyTxnInput) => void;
   handleDeletePropertyTxn: (id: number) => void;
@@ -143,7 +143,7 @@ export type PropertyModalsProps = {
   properties: Property[];
   mortgageById: Map<number, Mortgage>;
   onCloseUpdateProperty: () => void;
-  onSaveUpdateProperty: (id: number, value: number, rent: number) => void;
+  onSaveUpdateProperty: (id: number, value: number, rent: number, isJoint: boolean) => void;
   onCloseAddProperty: () => void;
   onSaveAddProperty: (property: Omit<Property, 'id'>) => void;
   onCloseAddPropertyTxn: () => void;

--- a/packages/frontend/src/features/mortgage/components/AddMortgageModal.tsx
+++ b/packages/frontend/src/features/mortgage/components/AddMortgageModal.tsx
@@ -1,6 +1,7 @@
 import { Modal, ModalFooter } from '@/components/ui';
 import { CURRENCY_CODES, useCurrency, type CurrencyCode } from '@/lib/CurrencyContext';
 import { formatNumber, type Mortgage as MortgageType, type Property } from '@quro/shared';
+import { JointToggleField } from '@/features/partner';
 import { useAddMortgageForm } from '../hooks';
 import type { MortgageFormPayload, MortgageFormState } from '../types';
 
@@ -144,8 +145,14 @@ function PropertyLinkSection({
 
 type LoanFinancialsSectionProps = { form: FormState; errors: Errors; setField: SetFieldFn };
 
+type LoanFinancialField =
+  | 'originalAmount'
+  | 'outstandingBalance'
+  | 'propertyValue'
+  | 'monthlyPayment';
+
 function LoanFinancialsSection({ form, errors, setField }: LoanFinancialsSectionProps) {
-  const fields = [
+  const fields: Array<{ field: LoanFinancialField; label: string; placeholder: string }> = [
     { field: 'originalAmount', label: 'Original Loan Amount', placeholder: '240000' },
     { field: 'outstandingBalance', label: 'Outstanding Balance', placeholder: '218600' },
     { field: 'propertyValue', label: 'Current Property Value', placeholder: '362000' },
@@ -172,8 +179,8 @@ function LoanFinancialsSection({ form, errors, setField }: LoanFinancialsSection
                 step="0.01"
                 className={`w-full rounded-xl border pl-12 pr-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-300 ${errors[field] ? 'border-rose-300 bg-rose-50' : 'border-slate-200 bg-slate-50'}`}
                 placeholder={placeholder}
-                value={form[field as keyof MortgageFormState]}
-                onChange={(e) => setField(field as keyof MortgageFormState, e.target.value)}
+                value={form[field]}
+                onChange={(e) => setField(field, e.target.value)}
               />
             </div>
             {errors[field] && <p className="text-xs text-rose-500 mt-1">{errors[field]}</p>}
@@ -394,6 +401,11 @@ function MortgageFormBody({
       <LoanFinancialsSection form={form} errors={errors} setField={setField} />
       <RateTermSection form={form} errors={errors} setField={setField} />
       <DatesSection form={form} setField={setField} />
+      <JointToggleField
+        checked={form.isJoint}
+        onChange={(checked) => setField('isJoint', checked)}
+        hint="Also applies to the linked property. Counts 50/50 in both dashboards."
+      />
       {ltvPreview && <LtvPreview ltvPreview={ltvPreview} form={form} />}
     </div>
   );

--- a/packages/frontend/src/features/mortgage/components/MortgageHeroCard.tsx
+++ b/packages/frontend/src/features/mortgage/components/MortgageHeroCard.tsx
@@ -1,5 +1,6 @@
 import { Edit3, Home } from 'lucide-react';
 import type { Mortgage as MortgageType } from '@quro/shared';
+import { JointBadge } from '@/features/partner';
 import type { MortgageFormatFn } from '../types';
 
 type MortgageHeroCardProps = {
@@ -49,7 +50,10 @@ export function MortgageHeroCard({
             <Home size={22} />
           </div>
           <div>
-            <h2 className="font-bold text-lg">{mortgage.propertyAddress}</h2>
+            <div className="flex items-center gap-2 flex-wrap">
+              <h2 className="font-bold text-lg">{mortgage.propertyAddress}</h2>
+              <JointBadge isJoint={mortgage.isJoint} ownerUserId={mortgage.userId} />
+            </div>
             <p className="text-slate-400 text-sm">
               {mortgage.lender} · {mortgage.rateType} Rate · Fixed until {mortgage.fixedUntil}
             </p>

--- a/packages/frontend/src/features/mortgage/hooks/useAddMortgageForm.ts
+++ b/packages/frontend/src/features/mortgage/hooks/useAddMortgageForm.ts
@@ -69,6 +69,7 @@ function buildPayload(form: MortgageFormState, existing?: MortgageType): Mortgag
     startDate: form.startDate.trim() || 'N/A',
     endDate: form.endDate.trim() || 'N/A',
     overpaymentLimit: n(form.overpaymentLimit) || DEFAULT_OVERPAYMENT_LIMIT_PERCENT,
+    isJoint: form.isJoint,
     ...(existing ? { id: existing.id } : {}),
   };
 }
@@ -113,6 +114,7 @@ function buildInitialMortgageState(
       startDate: '',
       endDate: '',
       overpaymentLimit: '10',
+      isJoint: false,
     };
   }
 
@@ -132,6 +134,7 @@ function buildInitialMortgageState(
     startDate: existing.startDate,
     endDate: existing.endDate,
     overpaymentLimit: String(existing.overpaymentLimit ?? '10'),
+    isJoint: existing.isJoint,
   };
 }
 

--- a/packages/frontend/src/features/mortgage/types.ts
+++ b/packages/frontend/src/features/mortgage/types.ts
@@ -33,6 +33,7 @@ export type MortgageFormState = {
   startDate: string;
   endDate: string;
   overpaymentLimit: string;
+  isJoint: boolean;
 };
 
 export type AmortizationRow = {

--- a/packages/frontend/src/features/mortgage/utils/mortgage-metrics.test.ts
+++ b/packages/frontend/src/features/mortgage/utils/mortgage-metrics.test.ts
@@ -21,6 +21,7 @@ const mortgageBase: Mortgage = {
   startDate: '2032-04-01',
   endDate: '2034-03-31',
   overpaymentLimit: 10,
+  isJoint: false,
 };
 
 test('derives mortgage projection years from the current mortgage schedule', () => {

--- a/packages/frontend/src/features/partner/components/JointBadge.tsx
+++ b/packages/frontend/src/features/partner/components/JointBadge.tsx
@@ -1,0 +1,24 @@
+import { Users } from 'lucide-react';
+import { Badge } from '@/components/ui';
+import { useAuth } from '@/lib/AuthContext';
+
+type JointBadgeProps = {
+  isJoint: boolean;
+  ownerUserId?: number;
+  size?: 'xs' | 'sm' | 'md';
+};
+
+// Marks a joint asset; adds "Partner's" when the row belongs to the partner.
+export function JointBadge({ isJoint, ownerUserId, size = 'sm' }: JointBadgeProps) {
+  const { user } = useAuth();
+  if (!isJoint) return null;
+
+  const ownedByPartner = ownerUserId !== undefined && user !== null && ownerUserId !== user.id;
+
+  return (
+    <Badge tone="brand" size={size}>
+      <Users size={11} />
+      {ownedByPartner ? "Joint · Partner's" : 'Joint'}
+    </Badge>
+  );
+}

--- a/packages/frontend/src/features/partner/components/JointToggleField.tsx
+++ b/packages/frontend/src/features/partner/components/JointToggleField.tsx
@@ -1,0 +1,46 @@
+import { Users } from 'lucide-react';
+import { getUserDisplayName } from '@/lib/user';
+import { cn } from '@/lib/utils';
+import { usePartner } from '../hooks';
+
+type JointToggleFieldProps = {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  hint?: string;
+  className?: string;
+};
+
+// Renders nothing unless an accepted partner link exists, so personal-only
+// users never see the joint option.
+export function JointToggleField({ checked, onChange, hint, className }: JointToggleFieldProps) {
+  const { data: link } = usePartner();
+  if (link?.status !== 'accepted') return null;
+
+  const partnerName = getUserDisplayName(link.partner);
+
+  return (
+    <label
+      className={cn(
+        'flex cursor-pointer items-start gap-3 rounded-xl border px-4 py-3 transition-colors',
+        checked ? 'border-indigo-300 bg-indigo-50/60' : 'border-slate-200 hover:border-slate-300',
+        className,
+      )}
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+        className="mt-0.5 h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+      />
+      <span className="min-w-0">
+        <span className="flex items-center gap-1.5 text-sm font-medium text-slate-900">
+          <Users size={14} className="text-indigo-500" />
+          Joint with {partnerName}
+        </span>
+        <span className="mt-0.5 block text-xs text-slate-500">
+          {hint ?? 'Both of you can view and edit this, and it counts 50/50 in your dashboards.'}
+        </span>
+      </span>
+    </label>
+  );
+}

--- a/packages/frontend/src/features/partner/components/PartnerSection.tsx
+++ b/packages/frontend/src/features/partner/components/PartnerSection.tsx
@@ -1,0 +1,288 @@
+import { useState } from 'react';
+import type { PartnerLink } from '@quro/shared';
+import { Check, Heart, Send, Unlink, X } from 'lucide-react';
+import { Badge, Button, FormField, TextInput } from '@/components/ui';
+import { resolveApiErrorMessage } from '@/lib/pdfDocuments';
+import { getUserDisplayName, getUserInitials } from '@/lib/user';
+import {
+  useAcceptPartner,
+  useDeclinePartner,
+  useInvitePartner,
+  usePartner,
+  useUnlinkPartner,
+} from '../hooks';
+
+function SectionError({ message }: { message: string | null }) {
+  if (!message) return null;
+  return (
+    <div className="rounded-xl border border-rose-100 bg-rose-50 px-4 py-3 text-sm text-rose-600">
+      {message}
+    </div>
+  );
+}
+
+function InviteForm() {
+  const invite = useInvitePartner();
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleInvite = async () => {
+    setError(null);
+    try {
+      await invite.mutateAsync(email);
+    } catch (e: unknown) {
+      setError(resolveApiErrorMessage(e, 'Failed to send invitation'));
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <SectionError message={error} />
+      <div className="rounded-xl border border-slate-200 p-5">
+        <p className="text-sm font-semibold text-slate-900">Invite your partner</p>
+        <p className="mt-1 text-sm text-slate-500">
+          Enter the email of their Quro account on this server. Once they accept, you can mark
+          savings accounts, your home, and mortgages as joint.
+        </p>
+        <div className="mt-4 flex items-end gap-3">
+          <div className="flex-1">
+            <FormField label="Partner's email">
+              <TextInput
+                type="email"
+                value={email}
+                placeholder="partner@example.com"
+                onChange={setEmail}
+              />
+            </FormField>
+          </div>
+          <Button
+            variant="primary"
+            size="md"
+            leadingIcon={<Send size={14} />}
+            loading={invite.isPending}
+            disabled={!email.trim()}
+            onClick={() => {
+              void handleInvite();
+            }}
+          >
+            Send invite
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PartnerIdentity({ link }: { link: PartnerLink }) {
+  return (
+    <div className="flex items-center gap-3">
+      <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-rose-400 to-indigo-500 text-base font-bold text-white">
+        {getUserInitials(link.partner)}
+      </div>
+      <div>
+        <p className="text-sm font-semibold text-slate-900">{getUserDisplayName(link.partner)}</p>
+        <p className="text-xs text-slate-500">{link.partner.email}</p>
+      </div>
+    </div>
+  );
+}
+
+function IncomingInvite({ link }: { link: PartnerLink }) {
+  const accept = useAcceptPartner();
+  const decline = useDeclinePartner();
+  const [error, setError] = useState<string | null>(null);
+
+  const run = async (action: () => Promise<unknown>, fallback: string) => {
+    setError(null);
+    try {
+      await action();
+    } catch (e: unknown) {
+      setError(resolveApiErrorMessage(e, fallback));
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <SectionError message={error} />
+      <div className="rounded-xl border border-indigo-200 bg-indigo-50/50 p-5">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <PartnerIdentity link={link} />
+            <p className="mt-3 text-sm text-slate-600">
+              wants to link accounts with you to share joint assets.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="primary"
+              size="sm"
+              leadingIcon={<Check size={14} />}
+              loading={accept.isPending}
+              onClick={() => {
+                void run(() => accept.mutateAsync(), 'Failed to accept invitation');
+              }}
+            >
+              Accept
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              leadingIcon={<X size={14} />}
+              loading={decline.isPending}
+              onClick={() => {
+                void run(() => decline.mutateAsync(), 'Failed to decline invitation');
+              }}
+            >
+              Decline
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function OutgoingInvite({ link }: { link: PartnerLink }) {
+  const cancel = useUnlinkPartner();
+  const [error, setError] = useState<string | null>(null);
+
+  const handleCancel = async () => {
+    setError(null);
+    try {
+      await cancel.mutateAsync();
+    } catch (e: unknown) {
+      setError(resolveApiErrorMessage(e, 'Failed to cancel invitation'));
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <SectionError message={error} />
+      <div className="rounded-xl border border-slate-200 p-5">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <PartnerIdentity link={link} />
+            <Badge tone="info">Invite sent</Badge>
+          </div>
+          <Button
+            variant="secondary"
+            size="sm"
+            leadingIcon={<X size={14} />}
+            loading={cancel.isPending}
+            onClick={() => {
+              void handleCancel();
+            }}
+          >
+            Cancel invite
+          </Button>
+        </div>
+        <p className="mt-3 text-sm text-slate-500">
+          Waiting for {getUserDisplayName(link.partner)} to accept in their Settings.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function LinkedPartner({ link }: { link: PartnerLink }) {
+  const unlink = useUnlinkPartner();
+  const [confirming, setConfirming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleUnlink = async () => {
+    setError(null);
+    try {
+      await unlink.mutateAsync();
+    } catch (e: unknown) {
+      setError(resolveApiErrorMessage(e, 'Failed to unlink partner'));
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <SectionError message={error} />
+      <div className="rounded-xl border border-slate-200 p-5">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <PartnerIdentity link={link} />
+            <Badge tone="success">
+              <Heart size={12} />
+              Linked
+            </Badge>
+          </div>
+          {confirming ? (
+            <div className="flex items-center gap-2">
+              <Button
+                variant="danger"
+                size="sm"
+                leadingIcon={<Unlink size={14} />}
+                loading={unlink.isPending}
+                onClick={() => {
+                  void handleUnlink();
+                }}
+              >
+                Confirm unlink
+              </Button>
+              <Button variant="secondary" size="sm" onClick={() => setConfirming(false)}>
+                Keep linked
+              </Button>
+            </div>
+          ) : (
+            <Button
+              variant="danger"
+              size="sm"
+              leadingIcon={<Unlink size={14} />}
+              onClick={() => setConfirming(true)}
+            >
+              Unlink
+            </Button>
+          )}
+        </div>
+        {confirming ? (
+          <p className="mt-3 text-sm text-rose-600">
+            Unlinking removes the joint flag from every shared asset — each asset stays with whoever
+            created it. This does not delete any data.
+          </p>
+        ) : (
+          <p className="mt-3 text-sm text-slate-500">
+            You can mark savings accounts, properties, and mortgages as joint. Joint assets are
+            visible and editable by both of you, and count 50/50 in each dashboard.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PartnerLinkState({ link }: { link: PartnerLink | null }) {
+  if (!link) return <InviteForm />;
+  if (link.status === 'accepted') return <LinkedPartner link={link} />;
+  return link.role === 'addressee' ? (
+    <IncomingInvite link={link} />
+  ) : (
+    <OutgoingInvite link={link} />
+  );
+}
+
+export function PartnerSection() {
+  const { data: link, isLoading } = usePartner();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-lg font-semibold text-slate-900">Partner</h3>
+        <p className="mt-1 text-sm text-slate-500">
+          Link your account with your partner&apos;s to track joint assets together.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-12 text-sm text-slate-400">
+          Loading...
+        </div>
+      ) : (
+        <PartnerLinkState link={link ?? null} />
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/features/partner/hooks/index.ts
+++ b/packages/frontend/src/features/partner/hooks/index.ts
@@ -1,0 +1,7 @@
+export { usePartner } from './usePartner';
+export {
+  useAcceptPartner,
+  useDeclinePartner,
+  useInvitePartner,
+  useUnlinkPartner,
+} from './usePartnerMutations';

--- a/packages/frontend/src/features/partner/hooks/usePartner.ts
+++ b/packages/frontend/src/features/partner/hooks/usePartner.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import type { PartnerLink } from '@quro/shared';
+import { api } from '@/lib/api';
+
+export function usePartner() {
+  return useQuery({
+    queryKey: ['partner'],
+    queryFn: async (): Promise<PartnerLink | null> => {
+      const { data } = await api.get('/api/partner');
+      return (data.data as PartnerLink | null) ?? null;
+    },
+  });
+}

--- a/packages/frontend/src/features/partner/hooks/usePartnerMutations.ts
+++ b/packages/frontend/src/features/partner/hooks/usePartnerMutations.ts
@@ -1,0 +1,59 @@
+import { useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query';
+import type { PartnerLink } from '@quro/shared';
+import { api } from '@/lib/api';
+
+function invalidatePartnerOnly(queryClient: QueryClient): void {
+  void queryClient.invalidateQueries({ queryKey: ['partner'] });
+}
+
+// Accepting or unlinking changes which assets are visible, so every asset
+// feature and the dashboard must refetch.
+function invalidatePartnerAndAssets(queryClient: QueryClient): void {
+  invalidatePartnerOnly(queryClient);
+  void queryClient.invalidateQueries({ queryKey: ['savings'] });
+  void queryClient.invalidateQueries({ queryKey: ['investments'] });
+  void queryClient.invalidateQueries({ queryKey: ['mortgages'] });
+  void queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+}
+
+export function useInvitePartner() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (email: string): Promise<PartnerLink> => {
+      const { data } = await api.post('/api/partner/invite', { email });
+      return data.data as PartnerLink;
+    },
+    onSuccess: () => invalidatePartnerOnly(queryClient),
+  });
+}
+
+export function useAcceptPartner() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (): Promise<PartnerLink> => {
+      const { data } = await api.post('/api/partner/accept');
+      return data.data as PartnerLink;
+    },
+    onSuccess: () => invalidatePartnerAndAssets(queryClient),
+  });
+}
+
+export function useDeclinePartner() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (): Promise<void> => {
+      await api.post('/api/partner/decline');
+    },
+    onSuccess: () => invalidatePartnerOnly(queryClient),
+  });
+}
+
+export function useUnlinkPartner() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (): Promise<void> => {
+      await api.delete('/api/partner');
+    },
+    onSuccess: () => invalidatePartnerAndAssets(queryClient),
+  });
+}

--- a/packages/frontend/src/features/partner/index.ts
+++ b/packages/frontend/src/features/partner/index.ts
@@ -1,0 +1,4 @@
+export { PartnerSection } from './components/PartnerSection';
+export { JointToggleField } from './components/JointToggleField';
+export { JointBadge } from './components/JointBadge';
+export * from './hooks';

--- a/packages/frontend/src/features/savings/components/AccountModal.tsx
+++ b/packages/frontend/src/features/savings/components/AccountModal.tsx
@@ -14,6 +14,7 @@ import {
   EmojiPickerField,
 } from '@/components/ui';
 import type { SavingsAccount } from '@quro/shared';
+import { JointToggleField } from '@/features/partner';
 import type { DeleteSavingsAccountMode, SaveAccountInput } from '../types';
 
 type AccountModalProps = {
@@ -43,6 +44,7 @@ type FormState = {
   rate: string;
   type: 'Easy Access' | 'Term Deposit';
   emoji: string;
+  isJoint: boolean;
 };
 
 function validateAccountForm(form: FormState): Record<string, string> {
@@ -67,6 +69,7 @@ function initialFormState(existing?: SavingsAccount): FormState {
       rate: '',
       type: 'Easy Access',
       emoji: '\ud83c\udfe6',
+      isJoint: false,
     };
   }
   return {
@@ -77,6 +80,7 @@ function initialFormState(existing?: SavingsAccount): FormState {
     rate: formatFixedInputValue(existing.interestRate),
     type: existing.accountType as 'Easy Access' | 'Term Deposit',
     emoji: existing.emoji,
+    isJoint: existing.isJoint,
   };
 }
 
@@ -107,7 +111,7 @@ function InterestPreview({
 type AccountFormBodyProps = {
   form: FormState;
   errors: Record<string, string>;
-  set: (field: string, value: string) => void;
+  set: (field: string, value: string | boolean) => void;
   isBunqSynced?: boolean;
 };
 
@@ -216,6 +220,7 @@ function AccountFormBody({
         balanceLabel={isEdit ? 'Balance' : 'Opening Balance'}
         isBunqSynced={isBunqSynced}
       />
+      <JointToggleField checked={form.isJoint} onChange={(checked) => set('isJoint', checked)} />
       <InterestPreview balance={form.balance} rate={form.rate} currency={form.currency} />
     </>
   );
@@ -230,7 +235,7 @@ function useAccountModalForm(
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [submitError, setSubmitError] = useState<string | null>(null);
 
-  function set(field: string, value: string): void {
+  function set(field: string, value: string | boolean): void {
     setForm((f) => ({ ...f, [field]: value }));
     if (errors[field])
       setErrors((e) => {
@@ -258,6 +263,7 @@ function useAccountModalForm(
         accountType: form.type,
         color: existing?.color ?? COLORS[Math.floor(Math.random() * COLORS.length)],
         emoji: form.emoji.trim(),
+        isJoint: form.isJoint,
       });
       onClose();
     } catch (e) {

--- a/packages/frontend/src/features/savings/components/AccountsList.tsx
+++ b/packages/frontend/src/features/savings/components/AccountsList.tsx
@@ -1,6 +1,7 @@
 import { Calendar, ChevronDown, ChevronUp, Edit3, Plus } from 'lucide-react';
 import type { SavingsAccount, SavingsTransaction } from '@quro/shared';
 import { Badge, Button, Card, IconButton, PanelHeader } from '@/components/ui';
+import { JointBadge } from '@/features/partner';
 import { TxnHistory } from './TxnHistory';
 import type {
   ConvertToBaseFn,
@@ -77,6 +78,7 @@ function AccountRowMeta({
             Bunq
           </Badge>
         )}
+        <JointBadge isJoint={acc.isJoint} ownerUserId={acc.userId} />
         <Badge tone="neutral" size="sm">
           {acc.accountType}
         </Badge>

--- a/packages/frontend/src/features/settings/SettingsPage.tsx
+++ b/packages/frontend/src/features/settings/SettingsPage.tsx
@@ -35,6 +35,7 @@ import {
   RefreshCw,
   Unlink,
   User as UserIcon,
+  Users,
 } from 'lucide-react';
 import {
   Badge,
@@ -52,6 +53,7 @@ import { useAuth } from '@/lib/AuthContext';
 import { resolveApiErrorMessage } from '@/lib/pdfDocuments';
 import { getUserDisplayName, getUserInitials } from '@/lib/user';
 import { cn } from '@/lib/utils';
+import { PartnerSection } from '@/features/partner';
 import {
   useBunqConnection,
   useCategoryMappings,
@@ -61,7 +63,7 @@ import {
   type CategoryMapping,
 } from './hooks';
 
-type TabKey = 'profile' | 'security' | 'preferences' | 'connections';
+type TabKey = 'profile' | 'security' | 'preferences' | 'partner' | 'connections';
 
 type StrengthState = {
   score: number;
@@ -122,6 +124,12 @@ const TABS: ReadonlyArray<{ key: TabKey; label: string; icon: ElementType; subti
     label: 'Preferences',
     icon: SlidersHorizontal,
     subtitle: 'Currency and display defaults',
+  },
+  {
+    key: 'partner',
+    label: 'Partner',
+    icon: Users,
+    subtitle: 'Share joint assets with your partner',
   },
   {
     key: 'connections',
@@ -1212,6 +1220,7 @@ export function Settings() {
             {activeTab === 'preferences' ? (
               <PreferencesSection user={user} replaceUser={replaceUser} />
             ) : null}
+            {activeTab === 'partner' ? <PartnerSection /> : null}
             {activeTab === 'connections' ? <ConnectionsSection /> : null}
           </Card>
         </div>

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -83,6 +83,28 @@ export type UpdateUserPasswordInput = {
   nextPassword: string;
 };
 
+export type PartnerLinkStatus = 'pending' | 'accepted';
+export type PartnerLinkRole = 'requester' | 'addressee';
+
+export type PartnerProfile = {
+  id: number;
+  firstName: string;
+  lastName: string;
+  email: string;
+};
+
+export type PartnerLink = {
+  id: number;
+  status: PartnerLinkStatus;
+  role: PartnerLinkRole;
+  createdAt: string;
+  partner: PartnerProfile;
+};
+
+export type InvitePartnerInput = {
+  email: string;
+};
+
 export const SAVINGS_ACCOUNT_TYPES = ['Easy Access', 'Term Deposit'] as const;
 export type SavingsAccountType = (typeof SAVINGS_ACCOUNT_TYPES)[number];
 
@@ -97,6 +119,8 @@ export type SavingsAccount = {
   color: string;
   emoji: string;
   bunqAccountId?: string | null;
+  isJoint: boolean;
+  userId?: number;
   archivedAt?: string | null;
 };
 
@@ -254,6 +278,8 @@ export type Property = {
   monthlyRent: number;
   currency: CurrencyCode;
   emoji: string;
+  isJoint: boolean;
+  userId?: number;
 };
 
 export const PROPERTY_TRANSACTION_TYPES = [
@@ -449,6 +475,8 @@ export type Mortgage = {
   startDate: string;
   endDate: string;
   overpaymentLimit: number;
+  isJoint: boolean;
+  userId?: number;
   archivedAt?: string | null;
 };
 
@@ -634,6 +662,7 @@ export type DashboardTransaction = {
   date: string;
   category: string;
   currency: CurrencyCode;
+  isJoint: boolean;
 };
 
 export type BunqConnection = {

--- a/services/pension-parser/requirements.txt
+++ b/services/pension-parser/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.135.1
 starlette==1.0.1
 uvicorn[standard]==0.37.0
 python-multipart==0.0.27
-pypdf==6.10.2
+pypdf==6.12.0
 httpx==0.28.1
 pdf2image==1.17.0
 pytesseract==0.3.13


### PR DESCRIPTION
## Why

We each have a Quro account, but some assets are genuinely shared — the house (property + mortgage) and joint savings accounts. Until now every row was hard-scoped to a single user, so shared assets had to live in one person's account and distort both net worths. This adds a first-class joint-asset mechanism on top of a 1:1 partner link.

## What changed

**Partner link**
- New `partner_links` table (unique per requester and addressee, no self-links, plus a `LEAST/GREATEST` pair index against crossed invites) and a `/api/partner` API: invite by email, accept/decline, unlink. Concurrent-invite races surface as 409, not 500.
- New Partner tab in Settings covering all four states: invite form, outgoing pending (cancel), incoming pending (accept/decline), linked (unlink with confirmation).

**Joint assets**
- `is_joint` flag on savings accounts, properties, and mortgages. Access scoping changes from `userId = me` to "owned by me, or owned by my accepted partner and joint" via a shared predicate (`lib/partner.ts`), applied across savings, mortgages, investments(properties), and dashboard routes. With no link the predicate degenerates to the old behavior.
- Transactions on joint assets are fully shared and always carry the asset owner's `userId`; access derives from the parent asset. The savings balance updater dropped its user scope (callers access-check first) — previously a partner's deposit would have silently skipped the balance update.
- Jointness propagates across linked property↔mortgage pairs in both directions, preventing mixed pairs that would corrupt equity math (half a house minus a full mortgage).
- Unlinking resets all joint flags transactionally; assets revert to their creators and partner-created transactions stay with the asset.

**Dashboard math**
- Joint assets count at 50% per partner in allocations and net-worth history (joint rows are pre-scaled at load time, exploiting the linearity of the existing formulas — compute functions untouched), so the two dashboards sum to reality.
- Feature pages and the activity feed keep full amounts with a "Joint" badge; only the monthly income/expense/savings summary halves joint rows.

**UI**
- "Joint with {partner}" toggle in the savings/property/mortgage forms (hidden without an accepted link), joint badges on lists, cards, and dashboard rows ("Joint · Partner's" when the partner created it).

Also bumps pypdf 6.10.2 → 6.12.0 in the pension parser (CVE-2026-48155/48156, flagged by the pip-audit commit gate).

## Out of scope

Pensions, salary, holdings, debts, goals, and budget stay strictly personal. Goals can't source from a partner's joint account, bunq sync stays bound to whoever connected it, and splits are fixed 50/50.

## Testing

- 8 new integration tests: link lifecycle, invite validation, full partner access control (incl. a balance-update regression test and third-user isolation), property↔mortgage propagation in both directions, unlink semantics, 50% allocation math, and activity-feed flags.
- Frontend unit test for the monthly-summary halving; `bun run ci:check` green.
- Manual two-account E2E: invite → accept → joint account created via the modal → partner badge + halved dashboard verified in the browser.

Deploy note: requires `bun run db:migrate` (migration `0017`, purely additive).