### PR TITLE
docs: align CLAUDE ESLint function limit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ Contains TypeScript types used by both frontend and backend. Imported as `@quro/
 
 ## Code Conventions
 
-- **ESLint rules to be aware of:** max 50 lines per function, max complexity 10, no floating promises, `readonly` preferred for params, strict equality required. Run `bun run lint` before committing.
+- **ESLint rules to be aware of:** max 80 lines per function (blank lines and comments excluded), max complexity 10, no floating promises, `readonly` preferred for params, strict equality required. Run `bun run lint` before committing.
 - **Prettier:** single quotes, 2-space indent, trailing commas everywhere, 100-char print width, LF line endings. Run `bun run format` before committing to auto-fix formatting, then verify with `bun run format:check` — both must pass before pushing.
 - **TypeScript:** strict mode enabled in all packages.
 


### PR DESCRIPTION
## Summary
- Update CLAUDE.md to document the enforced 80-line max-lines-per-function limit.
- Note that blank lines and comments are excluded, matching eslint.config.mjs.

## Test Plan
- `bun run lint` (passes with existing no-magic-number warnings)
- `bun run format:check`
- `git diff --check`

Closes #115