### PR TITLE
fix(savings): wrap transaction balance updates

### DIFF
--- a/packages/backend/src/lib/savingsBalance.ts
+++ b/packages/backend/src/lib/savingsBalance.ts
@@ -3,6 +3,8 @@ import { db } from '../db/client';
 import { savingsAccounts } from '../db/schema';
 import { parseNumber } from './requestValidation';
 
+type SavingsBalanceDb = Pick<typeof db, 'update'>;
+
 export function toFiniteNumber(value: unknown): number {
   const parsed = parseNumber(value);
   return parsed ?? 0;
@@ -17,11 +19,12 @@ export function toSignedSavingsAmount(type: unknown, amount: unknown): number {
 // invoking this; the update itself is intentionally not user-scoped so partner
 // transactions on joint accounts still adjust the balance.
 export async function updateSavingsAccountBalanceByDelta(
+  client: SavingsBalanceDb,
   accountId: number,
   delta: number,
 ): Promise<void> {
   if (delta === 0) return;
-  await db
+  await client
     .update(savingsAccounts)
     .set({
       balance: sql`CAST(${savingsAccounts.balance} AS numeric) + ${delta}`,

--- a/packages/backend/src/routes/savings.transaction-safety.test.ts
+++ b/packages/backend/src/routes/savings.transaction-safety.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const routeSource = readFileSync(new URL('./savings.ts', import.meta.url), 'utf8');
+const balanceSource = readFileSync(new URL('../lib/savingsBalance.ts', import.meta.url), 'utf8');
+
+describe('savings transaction mutation safety', () => {
+  test('transaction mutations keep row and balance updates in one database transaction', () => {
+    expect(routeSource).toContain('const [data] = await db.transaction(async (tx) => {');
+    expect(routeSource).toContain('await syncSavingsBalancesForEditedTransaction(tx, {');
+    expect(routeSource).toMatch(
+      /await updateSavingsAccountBalanceByDelta\(\s*tx,\s*deleted\.accountId/,
+    );
+  });
+
+  test('balance helper accepts the caller database client instead of escaping transactions', () => {
+    expect(balanceSource).toContain("type SavingsBalanceDb = Pick<typeof db, 'update'>;");
+    expect(balanceSource).toContain('client: SavingsBalanceDb');
+    expect(balanceSource).toContain('await client');
+  });
+});

--- a/packages/backend/src/routes/savings.ts
+++ b/packages/backend/src/routes/savings.ts
@@ -73,6 +73,7 @@ type SavingsTransactionPayload = {
 
 type SavingsAccountInsert = typeof savingsAccounts.$inferInsert;
 type SavingsTransactionInsert = typeof savingsTransactions.$inferInsert;
+type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
 function parseSavingsAccountTypeField(value: unknown): ParseResult<SavingsAccountType> {
   return typeof value === 'string' && SAVINGS_ACCOUNT_TYPES.includes(value as SavingsAccountType)
@@ -264,27 +265,31 @@ async function getAccessibleSavingsTransaction(
   return transaction ?? null;
 }
 
-async function syncSavingsBalancesForEditedTransaction(params: {
-  previousAccountId: number;
-  nextAccountId: number;
-  previousType: unknown;
-  nextType: unknown;
-  previousAmount: unknown;
-  nextAmount: unknown;
-}): Promise<void> {
+async function syncSavingsBalancesForEditedTransaction(
+  tx: DbTransaction,
+  params: {
+    previousAccountId: number;
+    nextAccountId: number;
+    previousType: unknown;
+    nextType: unknown;
+    previousAmount: unknown;
+    nextAmount: unknown;
+  },
+): Promise<void> {
   const oldSignedAmount = toSignedSavingsAmount(params.previousType, params.previousAmount);
   const newSignedAmount = toSignedSavingsAmount(params.nextType, params.nextAmount);
 
   if (params.nextAccountId === params.previousAccountId) {
     await updateSavingsAccountBalanceByDelta(
+      tx,
       params.previousAccountId,
       newSignedAmount - oldSignedAmount,
     );
     return;
   }
 
-  await updateSavingsAccountBalanceByDelta(params.previousAccountId, -oldSignedAmount);
-  await updateSavingsAccountBalanceByDelta(params.nextAccountId, newSignedAmount);
+  await updateSavingsAccountBalanceByDelta(tx, params.previousAccountId, -oldSignedAmount);
+  await updateSavingsAccountBalanceByDelta(tx, params.nextAccountId, newSignedAmount);
 }
 
 function resolveNextSavingsTransactionState(
@@ -516,15 +521,20 @@ app.post('/transactions', async (c) => {
     );
   }
 
-  const [data] = await db
-    .insert(savingsTransactions)
-    .values(toSavingsTransactionInsertValues(body.value, account.userId ?? user.id))
-    .returning();
+  const [data] = await db.transaction(async (tx) => {
+    const [inserted] = await tx
+      .insert(savingsTransactions)
+      .values(toSavingsTransactionInsertValues(body.value, account.userId ?? user.id))
+      .returning();
 
-  await updateSavingsAccountBalanceByDelta(
-    body.value.accountId,
-    toSignedSavingsAmount(body.value.type, body.value.amount),
-  );
+    await updateSavingsAccountBalanceByDelta(
+      tx,
+      body.value.accountId,
+      toSignedSavingsAmount(body.value.type, body.value.amount),
+    );
+
+    return [inserted];
+  });
 
   return c.json({ data }, HTTP_STATUS.CREATED);
 });
@@ -565,21 +575,27 @@ app.patch('/transactions/:id', async (c) => {
     updateValues.userId = nextAccount.nextAccountUserId;
   }
 
-  const [data] = await db
-    .update(savingsTransactions)
-    .set(updateValues)
-    .where(eq(savingsTransactions.id, id))
-    .returning();
-  if (!data) return c.json({ error: 'Transaction not found' }, HTTP_STATUS.NOT_FOUND);
+  const [data] = await db.transaction(async (tx) => {
+    const [updated] = await tx
+      .update(savingsTransactions)
+      .set(updateValues)
+      .where(eq(savingsTransactions.id, id))
+      .returning();
 
-  await syncSavingsBalancesForEditedTransaction({
-    previousAccountId: existing.accountId,
-    nextAccountId: nextState.accountId,
-    previousType: existing.type,
-    nextType: nextState.type,
-    previousAmount: existing.amount,
-    nextAmount: nextState.amount,
+    if (!updated) return [updated];
+
+    await syncSavingsBalancesForEditedTransaction(tx, {
+      previousAccountId: existing.accountId,
+      nextAccountId: nextState.accountId,
+      previousType: existing.type,
+      nextType: nextState.type,
+      previousAmount: existing.amount,
+      nextAmount: nextState.amount,
+    });
+
+    return [updated];
   });
+  if (!data) return c.json({ error: 'Transaction not found' }, HTTP_STATUS.NOT_FOUND);
 
   return c.json({ data });
 });
@@ -593,16 +609,23 @@ app.delete('/transactions/:id', async (c) => {
   const editable = await getEditableSavingsTransaction(id, user.id, partnerId, 'delete');
   if (!editable.ok) return c.json({ error: editable.error }, editable.status);
 
-  const [data] = await db
-    .delete(savingsTransactions)
-    .where(eq(savingsTransactions.id, id))
-    .returning();
-  if (!data) return c.json({ error: 'Transaction not found' }, HTTP_STATUS.NOT_FOUND);
+  const [data] = await db.transaction(async (tx) => {
+    const [deleted] = await tx
+      .delete(savingsTransactions)
+      .where(eq(savingsTransactions.id, id))
+      .returning();
 
-  await updateSavingsAccountBalanceByDelta(
-    data.accountId,
-    -toSignedSavingsAmount(data.type, data.amount),
-  );
+    if (!deleted) return [deleted];
+
+    await updateSavingsAccountBalanceByDelta(
+      tx,
+      deleted.accountId,
+      -toSignedSavingsAmount(deleted.type, deleted.amount),
+    );
+
+    return [deleted];
+  });
+  if (!data) return c.json({ error: 'Transaction not found' }, HTTP_STATUS.NOT_FOUND);
 
   return c.json({ data });
 });


### PR DESCRIPTION
## Summary
- Wrap savings transaction create, update, and delete balance changes in `db.transaction`.
- Thread the transaction client into savings balance helpers so balance writes do not escape the transaction.
- Add a regression guard for the transactional wiring.

## Test Plan
- `bun run lint` (passes with existing no-magic-number warnings)
- `bun run typecheck`
- `bun run format:check`
- `git diff --check`
- Node static guard for savings transaction wiring
- `PATH="/home/otto/.bun/bin:/home/otto/.local/bin:/home/otto/.local/bin:/home/otto/bin:/home/otto/.local/bin:/home/otto/.local/bin:/home/otto/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games" bun run test` currently crashes Bun 1.3.14 on this VM with CPU/no-AVX segfault before assertions; CI should run this normally.

Closes #116