### PR TITLE
feat(mortgage): edit existing mortgage transactions from the UI

### DIFF
--- a/packages/frontend/src/features/mortgage/MortgagePage.tsx
+++ b/packages/frontend/src/features/mortgage/MortgagePage.tsx
@@ -80,12 +80,13 @@ function MortgageContent({ state, mortgage }: Readonly<MortgageContentProps>) {
     <div className="p-6 space-y-6">
       <MortgageModals
         showTxnModal={state.showTxnModal}
+        editingTxn={state.editingTxn}
         showMortgageModal={state.showMortgageModal}
         mortgage={mortgage}
         editingMortgage={state.editingMortgage}
         properties={state.properties}
         editingLinkedPropertyId={state.editingLinkedPropertyId}
-        onCloseTxnModal={() => state.setShowTxnModal(false)}
+        onCloseTxnModal={state.closeTxnModal}
         onCloseMortgageModal={state.closeMortgageModal}
         onSaveTxn={state.handleAddTxn}
         onSaveMortgage={state.handleSaveMortgage}
@@ -133,6 +134,7 @@ function MortgageContent({ state, mortgage }: Readonly<MortgageContentProps>) {
         mortgage={mortgage}
         transactions={state.txns}
         onAdd={() => state.setShowTxnModal(true)}
+        onEdit={state.setEditingTxn}
         onDelete={state.handleDeleteTxn}
       />
       <MortgageTips mortgage={mortgage} fmt={state.fmt} overpaymentImpact={overpaymentImpact} />

--- a/packages/frontend/src/features/mortgage/components/AddMortgageTxnModal.tsx
+++ b/packages/frontend/src/features/mortgage/components/AddMortgageTxnModal.tsx
@@ -2,14 +2,28 @@ import { Modal, ModalFooter, ModalHeader } from '@/components/ui';
 import { useCurrency } from '@/lib/CurrencyContext';
 import type { Mortgage as MortgageType, MortgageTransaction } from '@quro/shared';
 import { useMortgageTxnModal } from '../hooks';
-import type { MortgageTxnType } from '../types';
+import type { MortgageTxnType, SaveMortgageTxnInput } from '../types';
 import { MORTGAGE_TXN_TYPES, TXN_META } from '../utils/mortgage-meta';
 
 type AddMortgageTxnModalProps = {
   mortgage: MortgageType;
+  existing?: MortgageTransaction;
   onClose: () => void;
-  onSave: (t: Omit<MortgageTransaction, 'id'>) => void;
+  onSave: (t: SaveMortgageTxnInput) => void;
 };
+
+// When editing a repayment, the mortgage balance already reflects the old
+// transaction's principal. Add it back so the live preview reflects the balance
+// before the edited repayment is applied.
+function buildEffectiveMortgage(
+  mortgage: MortgageType,
+  existing?: MortgageTransaction,
+): MortgageType {
+  if (existing?.type !== 'repayment') return mortgage;
+  const existingPrincipal =
+    existing.principal ?? Math.max(0, existing.amount - (existing.interest ?? 0));
+  return { ...mortgage, outstandingBalance: mortgage.outstandingBalance + existingPrincipal };
+}
 
 // ─── Type Selector ────────────────────────────────────────────────────────────
 
@@ -483,14 +497,22 @@ function TxnModalFormBody({ state, mortgage, fmt }: TxnModalFormBodyProps) {
 
 // ─── Main Component ───────────────────────────────────────────────────────────
 
-export function AddMortgageTxnModal({ mortgage, onClose, onSave }: AddMortgageTxnModalProps) {
+export function AddMortgageTxnModal({
+  mortgage,
+  existing,
+  onClose,
+  onSave,
+}: AddMortgageTxnModalProps) {
   const { fmtBase } = useCurrency();
   const fmt = (v: number) => fmtBase(v);
-  const state = useMortgageTxnModal({ mortgage, onSave, onClose });
+  const effectiveMortgage = buildEffectiveMortgage(mortgage, existing);
+  const state = useMortgageTxnModal({ mortgage: effectiveMortgage, existing, onSave, onClose });
+  const isEditing = Boolean(existing);
+  const title = isEditing ? 'Edit Transaction' : 'Record Transaction';
 
   return (
     <Modal
-      title="Record Transaction"
+      title={title}
       subtitle={`🏠 ${mortgage.propertyAddress}`}
       onClose={onClose}
       maxWidth="md"
@@ -498,15 +520,21 @@ export function AddMortgageTxnModal({ mortgage, onClose, onSave }: AddMortgageTx
       header={
         <ModalHeader
           onClose={onClose}
-          title="Record Transaction"
+          title={title}
           subtitle={`🏠 ${mortgage.propertyAddress}`}
           contentClassName="min-w-0"
           subtitleClassName="truncate max-w-[240px]"
         />
       }
-      footer={<ModalFooter onCancel={onClose} onConfirm={state.handleSave} confirmLabel="Record" />}
+      footer={
+        <ModalFooter
+          onCancel={onClose}
+          onConfirm={state.handleSave}
+          confirmLabel={isEditing ? 'Save Changes' : 'Record'}
+        />
+      }
     >
-      <TxnModalFormBody state={state} mortgage={mortgage} fmt={fmt} />
+      <TxnModalFormBody state={state} mortgage={effectiveMortgage} fmt={fmt} />
     </Modal>
   );
 }

--- a/packages/frontend/src/features/mortgage/components/MortgageModals.tsx
+++ b/packages/frontend/src/features/mortgage/components/MortgageModals.tsx
@@ -1,11 +1,12 @@
 import type { Mortgage as MortgageType, MortgageTransaction, Property } from '@quro/shared';
-import type { MortgageFormPayload } from '../types';
+import type { MortgageFormPayload, SaveMortgageTxnInput } from '../types';
 import type { DeleteMortgageMode } from '../hooks/useDeleteMortgage';
 import { AddMortgageModal } from './AddMortgageModal';
 import { AddMortgageTxnModal } from './AddMortgageTxnModal';
 
 type MortgageModalsProps = {
   showTxnModal: boolean;
+  editingTxn: MortgageTransaction | null;
   showMortgageModal: boolean;
   mortgage: MortgageType;
   editingMortgage: MortgageType | null;
@@ -13,13 +14,14 @@ type MortgageModalsProps = {
   editingLinkedPropertyId: number | null;
   onCloseTxnModal: () => void;
   onCloseMortgageModal: () => void;
-  onSaveTxn: (t: Omit<MortgageTransaction, 'id'>) => void;
+  onSaveTxn: (t: SaveMortgageTxnInput) => void;
   onSaveMortgage: (payload: MortgageFormPayload) => Promise<void>;
   onDeleteMortgage: (id: number, mode?: DeleteMortgageMode) => void;
 };
 
 export function MortgageModals({
   showTxnModal,
+  editingTxn,
   showMortgageModal,
   mortgage,
   editingMortgage,
@@ -33,8 +35,13 @@ export function MortgageModals({
 }: Readonly<MortgageModalsProps>) {
   return (
     <>
-      {showTxnModal && (
-        <AddMortgageTxnModal mortgage={mortgage} onClose={onCloseTxnModal} onSave={onSaveTxn} />
+      {(showTxnModal || editingTxn) && (
+        <AddMortgageTxnModal
+          mortgage={mortgage}
+          existing={editingTxn ?? undefined}
+          onClose={onCloseTxnModal}
+          onSave={onSaveTxn}
+        />
       )}
       {showMortgageModal && (
         <AddMortgageModal

--- a/packages/frontend/src/features/mortgage/components/MortgageTxnHistory.tsx
+++ b/packages/frontend/src/features/mortgage/components/MortgageTxnHistory.tsx
@@ -10,12 +10,14 @@ type MortgageTxnHistoryProps = {
   currency?: string;
   transactions: MortgageTransaction[];
   onAdd: () => void;
+  onEdit: (transaction: MortgageTransaction) => void;
   onDelete: (id: number) => void;
 };
 
 type MortgageTxnRowProps = {
   t: MortgageTransaction;
   fmt: (n: number) => string;
+  onEdit: (transaction: MortgageTransaction) => void;
   onDelete: (id: number) => void;
 };
 function MortgageTxnAmount({ t, fmt }: Pick<MortgageTxnRowProps, 't' | 'fmt'>) {
@@ -51,7 +53,7 @@ function MortgageTxnAmount({ t, fmt }: Pick<MortgageTxnRowProps, 't' | 'fmt'>) {
   );
 }
 
-function MortgageTxnRow({ t, fmt, onDelete }: MortgageTxnRowProps) {
+function MortgageTxnRow({ t, fmt, onEdit, onDelete }: MortgageTxnRowProps) {
   const m = TXN_META[t.type];
   return (
     <TxnRow
@@ -65,6 +67,7 @@ function MortgageTxnRow({ t, fmt, onDelete }: MortgageTxnRowProps) {
       date={t.date}
       dateClassName="text-xs text-slate-400"
       amount={<MortgageTxnAmount t={t} fmt={fmt} />}
+      onEdit={() => onEdit(t)}
       onDelete={() => onDelete(t.id)}
       className="rounded-none border-0 bg-transparent px-5 py-3 hover:bg-slate-50/60"
     />
@@ -94,6 +97,7 @@ export function MortgageTxnHistory({
   currency,
   transactions,
   onAdd,
+  onEdit,
   onDelete,
 }: MortgageTxnHistoryProps) {
   const { fmtBase } = useCurrency();
@@ -122,7 +126,7 @@ export function MortgageTxnHistory({
       isEmpty={sorted.length === 0}
     >
       {sorted.map((t) => (
-        <MortgageTxnRow key={t.id} t={t} fmt={fmt} onDelete={onDelete} />
+        <MortgageTxnRow key={t.id} t={t} fmt={fmt} onEdit={onEdit} onDelete={onDelete} />
       ))}
     </TxnHistoryPanel>
   );

--- a/packages/frontend/src/features/mortgage/hooks/index.ts
+++ b/packages/frontend/src/features/mortgage/hooks/index.ts
@@ -8,3 +8,4 @@ export { useArchivedMortgages, useMortgages } from './useMortgages';
 export { useMortgageTransactions } from './useMortgageTransactions';
 export { useMortgageTxnModal } from './useMortgageTxnModal';
 export { useUpdateMortgage } from './useUpdateMortgage';
+export { useUpdateMortgageTransaction } from './useUpdateMortgageTransaction';

--- a/packages/frontend/src/features/mortgage/hooks/useMortgageModals.ts
+++ b/packages/frontend/src/features/mortgage/hooks/useMortgageModals.ts
@@ -1,10 +1,16 @@
 import { useState } from 'react';
-import type { Mortgage as MortgageType } from '@quro/shared';
+import type { Mortgage as MortgageType, MortgageTransaction } from '@quro/shared';
 
 export function useMortgageModals() {
   const [showTxnModal, setShowTxnModal] = useState(false);
+  const [editingTxn, setEditingTxn] = useState<MortgageTransaction | null>(null);
   const [showMortgageModal, setShowMortgageModal] = useState(false);
   const [editingMortgage, setEditingMortgage] = useState<MortgageType | null>(null);
+
+  const closeTxnModal = () => {
+    setShowTxnModal(false);
+    setEditingTxn(null);
+  };
 
   const closeMortgageModal = () => {
     setShowMortgageModal(false);
@@ -14,6 +20,9 @@ export function useMortgageModals() {
   return {
     showTxnModal,
     setShowTxnModal,
+    editingTxn,
+    setEditingTxn,
+    closeTxnModal,
     showMortgageModal,
     setShowMortgageModal,
     editingMortgage,

--- a/packages/frontend/src/features/mortgage/hooks/useMortgagePageState.ts
+++ b/packages/frontend/src/features/mortgage/hooks/useMortgagePageState.ts
@@ -6,6 +6,7 @@ import type {
   CreateMortgagePayload,
   MortgageFormPayload,
   MortgagePageState,
+  SaveMortgageTxnInput,
   UpdateMortgagePayload,
 } from '../types';
 import { useCreateMortgage } from './useCreateMortgage';
@@ -16,6 +17,7 @@ import { useMortgageModals } from './useMortgageModals';
 import { useMortgages } from './useMortgages';
 import { useMortgageTransactions } from './useMortgageTransactions';
 import { useUpdateMortgage } from './useUpdateMortgage';
+import { useUpdateMortgageTransaction } from './useUpdateMortgageTransaction';
 
 function buildLinkedPropertyMap(properties: Property[]): Map<number, Property> {
   const map = new Map<number, Property>();
@@ -37,6 +39,7 @@ export function useMortgagePageState(): MortgagePageState {
   const createMortgageMut = useCreateMortgage();
   const updateMortgageMut = useUpdateMortgage();
   const createTxn = useCreateMortgageTransaction();
+  const updateTxn = useUpdateMortgageTransaction();
   const deleteTxnMut = useDeleteMortgageTransaction();
   const deleteMortgageMut = useDeleteMortgage();
 
@@ -50,8 +53,14 @@ export function useMortgagePageState(): MortgagePageState {
     ? (linkedPropertyByMortgageId.get(modals.editingMortgage.id)?.id ?? null)
     : null;
 
-  const handleAddTxn = (transaction: Omit<MortgageTransaction, 'id'>) =>
-    createTxn.mutate(transaction);
+  const handleAddTxn = (transaction: SaveMortgageTxnInput) => {
+    const { id, ...payload } = transaction;
+    if (typeof id === 'number') {
+      updateTxn.mutate({ id, ...payload } as MortgageTransaction);
+      return;
+    }
+    createTxn.mutate(payload);
+  };
   const handleDeleteTxn = (id: number) => deleteTxnMut.mutate(id);
   const handleDeleteMortgage = (id: number, mode: DeleteMortgageMode = 'preserveTransactions') => {
     deleteMortgageMut.mutate({ id, mode });

--- a/packages/frontend/src/features/mortgage/hooks/useMortgageTxnModal.ts
+++ b/packages/frontend/src/features/mortgage/hooks/useMortgageTxnModal.ts
@@ -1,10 +1,12 @@
 import { useState } from 'react';
 import type { Mortgage as MortgageType, MortgageTransaction } from '@quro/shared';
-import type { MortgageTxnType } from '../types';
+import { formatFixedInputValue } from '@/lib/utils';
+import type { MortgageTxnType, SaveMortgageTxnInput } from '../types';
 
 type UseMortgageTxnModalParams = {
   mortgage: MortgageType;
-  onSave: (t: Omit<MortgageTransaction, 'id'>) => void;
+  existing?: MortgageTransaction;
+  onSave: (t: SaveMortgageTxnInput) => void;
   onClose: () => void;
 };
 
@@ -37,13 +39,37 @@ function computeFixedUntil(date: string, parsedFixedYears: number): string | nul
   return d.toLocaleDateString('en-GB', { month: 'long', year: 'numeric' });
 }
 
-function useMortgageTxnFormState() {
-  const [type, setType] = useState<MortgageTxnType>('repayment');
-  const [amount, setAmount] = useState('');
-  const [interest, setInterest] = useState('');
-  const [fixedYears, setFixedYears] = useState('');
-  const [date, setDate] = useState(new Date().toISOString().slice(0, ISO_DATE_LENGTH));
-  const [note, setNote] = useState('');
+function emptyTxnFormValues() {
+  return {
+    type: 'repayment' as MortgageTxnType,
+    amount: '',
+    interest: '',
+    fixedYears: '',
+    date: new Date().toISOString().slice(0, ISO_DATE_LENGTH),
+    note: '',
+  };
+}
+
+function getInitialTxnFormValues(existing?: MortgageTransaction) {
+  if (!existing) return emptyTxnFormValues();
+  return {
+    type: existing.type,
+    amount: formatFixedInputValue(existing.amount),
+    interest: existing.interest != null ? formatFixedInputValue(existing.interest) : '',
+    fixedYears: existing.fixedYears != null ? String(existing.fixedYears) : '',
+    date: existing.date,
+    note: existing.note,
+  };
+}
+
+function useMortgageTxnFormState(existing?: MortgageTransaction) {
+  const initial = getInitialTxnFormValues(existing);
+  const [type, setType] = useState<MortgageTxnType>(initial.type);
+  const [amount, setAmount] = useState(initial.amount);
+  const [interest, setInterest] = useState(initial.interest);
+  const [fixedYears, setFixedYears] = useState(initial.fixedYears);
+  const [date, setDate] = useState(initial.date);
+  const [note, setNote] = useState(initial.note);
   const [error, setError] = useState('');
 
   return {
@@ -64,8 +90,13 @@ function useMortgageTxnFormState() {
   };
 }
 
-export function useMortgageTxnModal({ mortgage, onSave, onClose }: UseMortgageTxnModalParams) {
-  const formState = useMortgageTxnFormState();
+export function useMortgageTxnModal({
+  mortgage,
+  existing,
+  onSave,
+  onClose,
+}: UseMortgageTxnModalParams) {
+  const formState = useMortgageTxnFormState(existing);
   const { type, amount, interest, fixedYears, date, note } = formState;
   const { setType, setError, setAmount, setInterest, setFixedYears } = formState;
 
@@ -90,7 +121,7 @@ export function useMortgageTxnModal({ mortgage, onSave, onClose }: UseMortgageTx
       return;
     }
 
-    onSave({
+    const payload = {
       mortgageId: mortgage.id,
       type,
       amount: parsedAmount,
@@ -99,7 +130,8 @@ export function useMortgageTxnModal({ mortgage, onSave, onClose }: UseMortgageTx
       fixedYears: type === 'rate_change' ? parsedFixedYears : null,
       date,
       note,
-    });
+    };
+    onSave(existing ? { id: existing.id, ...payload } : payload);
     onClose();
   };
 

--- a/packages/frontend/src/features/mortgage/hooks/useUpdateMortgageTransaction.ts
+++ b/packages/frontend/src/features/mortgage/hooks/useUpdateMortgageTransaction.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { MortgageTransaction } from '@quro/shared';
+import { api } from '@/lib/api';
+import { normalizeMortgageTransaction } from '../utils/mortgage-normalizers';
+
+export function useUpdateMortgageTransaction() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, ...txn }: MortgageTransaction) => {
+      const { data } = await api.patch(`/api/mortgages/transactions/${id}`, txn);
+      return normalizeMortgageTransaction(data.data as MortgageTransaction);
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['mortgages'] });
+      void qc.invalidateQueries({ queryKey: ['dashboard'] });
+    },
+  });
+}

--- a/packages/frontend/src/features/mortgage/types.ts
+++ b/packages/frontend/src/features/mortgage/types.ts
@@ -6,6 +6,8 @@ export type MortgageFormatFn = (n: number) => string;
 export type MortgageTxnType = 'repayment' | 'valuation' | 'rate_change';
 export type MortgageTxnFilter = MortgageTxnType | 'all';
 
+export type SaveMortgageTxnInput = Omit<MortgageTransaction, 'id'> & { id?: number };
+
 export type CreateMortgagePayload = Omit<MortgageType, 'id'> & {
   linkedPropertyId: number;
 };
@@ -64,13 +66,16 @@ export type MortgagePageState = {
   txns: MortgageTransaction[];
   showTxnModal: boolean;
   setShowTxnModal: (v: boolean) => void;
+  editingTxn: MortgageTransaction | null;
+  setEditingTxn: (v: MortgageTransaction | null) => void;
+  closeTxnModal: () => void;
   showMortgageModal: boolean;
   setShowMortgageModal: (v: boolean) => void;
   editingMortgage: MortgageType | null;
   setEditingMortgage: (v: MortgageType | null) => void;
   editingLinkedPropertyId: number | null;
   setActiveMortgageId: (id: number | null) => void;
-  handleAddTxn: (transaction: Omit<MortgageTransaction, 'id'>) => void;
+  handleAddTxn: (transaction: SaveMortgageTxnInput) => void;
   handleSaveMortgage: (payload: MortgageFormPayload) => Promise<void>;
   handleDeleteTxn: (id: number) => void;
   handleDeleteMortgage: (id: number, mode?: 'preserveTransactions' | 'deleteTransactions') => void;


### PR DESCRIPTION
## What

Adds the ability to edit an existing mortgage transaction from the mortgage page. Previously the UI only supported adding and deleting transactions, even though the backend already exposed `PATCH /api/mortgages/transactions/:id` (which reconciles the mortgage's outstanding balance by reversing the old transaction's effect and applying the edited one inside a `db.transaction`).

## Changes

- **New hook** `useUpdateMortgageTransaction` — issues the `PATCH`, normalizes the response, and invalidates the `['mortgages']` and `['dashboard']` query keys (mirrors the create/delete hooks).
- **`MortgageTxnHistory`** — adds a per-row edit (pencil) button and an `onEdit` callback, mirroring `PropertyTxnHistory` in the investments feature.
- **`useMortgageModals`** — tracks an `editingTxn` target alongside the add flag, with a `closeTxnModal` that clears both.
- **`AddMortgageTxnModal` / `useMortgageTxnModal`** — accept an optional `existing` transaction and prefill the form (type, amount, interest, fixed years, date, note). When editing a repayment, the live-preview balance adds back the old transaction's principal so the projected balance stays accurate. The modal title and confirm label switch to "Edit Transaction" / "Save Changes".
- **`useMortgagePageState`** — `handleAddTxn` now routes to update vs. create based on whether the transaction carries an `id`, threading the editing state and `onEdit` through `MortgagePage` → `MortgageModals`.

## Why

Brings the mortgage transaction history to parity with the investments-property transaction history, which already supported inline editing. Without this, correcting a mistyped repayment/valuation/rate-change required deleting and re-adding the transaction.

## Verification

- `bun run --filter '@quro/frontend' typecheck` — passes
- `eslint` on all changed files — clean (functions kept under 50 lines, complexity ≤ 10)
- Full pre-commit CI suite (format, lint, typecheck, build, security audits) — passes