### PR TITLE
fix: share mortgage rate type options

### DIFF
--- a/packages/backend/src/routes/mortgages.ts
+++ b/packages/backend/src/routes/mortgages.ts
@@ -1,7 +1,9 @@
 import { Hono } from 'hono';
 import {
+  MORTGAGE_RATE_TYPES,
   MORTGAGE_TRANSACTION_TYPES,
   type CurrencyCode,
+  type MortgageRateType,
   type MortgageTransactionType,
 } from '@quro/shared';
 import { db } from '../db/client';
@@ -63,7 +65,6 @@ const MORTGAGE_TRANSACTION_FIELDS = [
   'note',
   'fixedYears',
 ] as const;
-type MortgageRateType = 'Fixed' | 'Variable';
 
 type MortgagePayload = {
   linkedPropertyId: number;
@@ -143,9 +144,8 @@ function parseOptionalNormalizedDecimalField(
 function parseMortgageRateTypeField(value: unknown): ParseResult<MortgageRateType> {
   if (typeof value !== 'string') return err('Invalid mortgage rate type');
   const normalized = value.trim().toLowerCase();
-  if (normalized === 'fixed') return ok('Fixed');
-  if (normalized === 'variable') return ok('Variable');
-  return err('Invalid mortgage rate type');
+  const rateType = MORTGAGE_RATE_TYPES.find((type) => type.toLowerCase() === normalized);
+  return rateType ? ok(rateType) : err('Invalid mortgage rate type');
 }
 
 function parseMortgageTransactionTypeField(value: unknown): ParseResult<MortgageTransactionType> {

--- a/packages/frontend/src/features/mortgage/components/AddMortgageModal.test.tsx
+++ b/packages/frontend/src/features/mortgage/components/AddMortgageModal.test.tsx
@@ -1,0 +1,11 @@
+/// <reference types="bun-types" />
+
+import { expect, test } from 'bun:test';
+import { MORTGAGE_RATE_TYPES } from '@quro/shared';
+import { RATE_TYPES } from './AddMortgageModal';
+
+test('mortgage rate type options come from the shared backend contract', () => {
+  expect(RATE_TYPES).toEqual([...MORTGAGE_RATE_TYPES]);
+  expect(RATE_TYPES).not.toContain('Tracker');
+  expect(RATE_TYPES).not.toContain('Offset');
+});

--- a/packages/frontend/src/features/mortgage/components/AddMortgageModal.tsx
+++ b/packages/frontend/src/features/mortgage/components/AddMortgageModal.tsx
@@ -2,7 +2,13 @@ import { useState } from 'react';
 import { Trash2 } from 'lucide-react';
 import { ArchiveOrDeleteDialog, Modal, ModalFooter } from '@/components/ui';
 import { useCurrency } from '@/lib/CurrencyContext';
-import { formatNumber, type Mortgage as MortgageType, type Property } from '@quro/shared';
+import {
+  formatNumber,
+  MORTGAGE_RATE_TYPES,
+  type Mortgage as MortgageType,
+  type MortgageRateType,
+  type Property,
+} from '@quro/shared';
 import { JointToggleField } from '@/features/partner';
 import { useAddMortgageForm } from '../hooks';
 import type { DeleteMortgageMode } from '../hooks/useDeleteMortgage';
@@ -19,9 +25,15 @@ type AddMortgageModalProps = {
   onDelete?: (id: number, mode?: DeleteMortgageMode) => void;
 };
 
-const RATE_TYPES = ['Fixed', 'Variable', 'Tracker', 'Offset'];
+export const RATE_TYPES = [...MORTGAGE_RATE_TYPES];
 const LOW_LTV_THRESHOLD = 70;
 const MEDIUM_LTV_THRESHOLD = 85;
+
+function toMortgageRateType(value: string): MortgageRateType {
+  return MORTGAGE_RATE_TYPES.includes(value as MortgageRateType)
+    ? (value as MortgageRateType)
+    : 'Fixed';
+}
 
 const n = (value: string) => parseFloat(value) || 0;
 
@@ -295,7 +307,7 @@ function RateTermSection({ form, errors, setField }: RateTermSectionProps) {
           <select
             className="w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-300"
             value={form.rateType}
-            onChange={(e) => setField('rateType', e.target.value)}
+            onChange={(e) => setField('rateType', toMortgageRateType(e.target.value))}
           >
             {RATE_TYPES.map((type) => (
               <option key={type}>{type}</option>

--- a/packages/frontend/src/features/mortgage/types.ts
+++ b/packages/frontend/src/features/mortgage/types.ts
@@ -1,5 +1,10 @@
 import type { CurrencyCode } from '@/lib/CurrencyContext';
-import type { Mortgage as MortgageType, MortgageTransaction, Property } from '@quro/shared';
+import type {
+  Mortgage as MortgageType,
+  MortgageRateType,
+  MortgageTransaction,
+  Property,
+} from '@quro/shared';
 
 export type MortgageFormatFn = (n: number) => string;
 
@@ -29,7 +34,7 @@ export type MortgageFormState = {
   propertyValue: string;
   monthlyPayment: string;
   interestRate: string;
-  rateType: string;
+  rateType: MortgageRateType;
   fixedUntil: string;
   termYears: string;
   startDate: string;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -459,6 +459,9 @@ export type PensionStatementImportRow = {
   updatedAt: string;
 };
 
+export const MORTGAGE_RATE_TYPES = ['Fixed', 'Variable'] as const;
+export type MortgageRateType = (typeof MORTGAGE_RATE_TYPES)[number];
+
 export type Mortgage = {
   id: number;
   linkedPropertyId?: number | null;
@@ -470,7 +473,7 @@ export type Mortgage = {
   propertyValue: number;
   monthlyPayment: number;
   interestRate: number;
-  rateType: string;
+  rateType: MortgageRateType;
   fixedUntil: string;
   termYears: number;
   startDate: string;


### PR DESCRIPTION
## Summary
- Defines `MORTGAGE_RATE_TYPES` and `MortgageRateType` once in `@quro/shared`.
- Uses the shared rate-type contract in the backend mortgage validator and payload type.
- Builds the Add/Edit Mortgage rate dropdown from the shared values, removing `Tracker` and `Offset`.
- Tightens `Mortgage.rateType` and `MortgageFormState.rateType` to the shared union.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run format:check`
- [x] `bun run lint` (warnings only; existing `no-magic-numbers` warnings)
- [x] `bun run build`

Closes #146
