### PR TITLE
fix: await savings transaction saves

### DIFF
--- a/packages/frontend/src/features/savings/SavingsPage.tsx
+++ b/packages/frontend/src/features/savings/SavingsPage.tsx
@@ -31,7 +31,7 @@ type SavingsPageBodyProps = {
   editingTxn: SavingsTransaction | null;
   onSaveAccount: (account: SaveAccountInput) => Promise<void>;
   onDeleteAccount: (id: number, mode: DeleteSavingsAccountMode) => Promise<void>;
-  onSaveTxn: (transaction: SaveTransactionInput) => void;
+  onSaveTxn: (transaction: SaveTransactionInput) => Promise<void>;
   onDeleteTxn: (id: number) => void;
   contribChartData: ReturnType<typeof useContribChartData>;
   growthChartData: ReturnType<typeof useGrowthChartData>;
@@ -181,13 +181,13 @@ export function Savings() {
       addTxnFor={addTxnFor}
       onSaveAccount={onSaveAccount}
       onDeleteAccount={(id, mode) => deleteAccount.mutateAsync({ id, mode })}
-      onSaveTxn={(transaction) => {
+      onSaveTxn={async (transaction) => {
         if (transaction.id) {
           const { id, ...payload } = transaction;
-          updateTxn.mutate({ id, ...payload });
+          await updateTxn.mutateAsync({ id, ...payload });
           return;
         }
-        createTxn.mutate(transaction);
+        await createTxn.mutateAsync(transaction);
       }}
       onDeleteTxn={(id) => deleteTxn.mutate(id)}
       setEditingTxn={setEditingTxn}

--- a/packages/frontend/src/features/savings/components/AddTxnModal.test.ts
+++ b/packages/frontend/src/features/savings/components/AddTxnModal.test.ts
@@ -1,0 +1,53 @@
+/// <reference types="bun-types" />
+
+import { expect, test } from 'bun:test';
+import { saveSavingsTransaction } from '../utils/save-transaction';
+import type { SaveTransactionInput } from '../types';
+
+const transaction: SaveTransactionInput = {
+  accountId: 1,
+  type: 'deposit',
+  amount: 25,
+  date: '2026-06-20',
+  note: 'Test deposit',
+};
+
+test('saveSavingsTransaction closes only after a successful save', async () => {
+  let closed = false;
+  let error = '';
+
+  await saveSavingsTransaction({
+    transaction,
+    onSave: async () => {},
+    onClose: () => {
+      closed = true;
+    },
+    setError: (message) => {
+      error = message;
+    },
+  });
+
+  expect(closed).toBe(true);
+  expect(error).toBe('');
+});
+
+test('saveSavingsTransaction keeps the modal open and reports errors when save fails', async () => {
+  let closed = false;
+  let error = '';
+
+  await saveSavingsTransaction({
+    transaction,
+    onSave: async () => {
+      throw new Error('API failed');
+    },
+    onClose: () => {
+      closed = true;
+    },
+    setError: (message) => {
+      error = message;
+    },
+  });
+
+  expect(closed).toBe(false);
+  expect(error).toBe('Failed to save transaction. Please try again.');
+});

--- a/packages/frontend/src/features/savings/components/AddTxnModal.tsx
+++ b/packages/frontend/src/features/savings/components/AddTxnModal.tsx
@@ -12,6 +12,7 @@ import {
 import type { SavingsAccount, SavingsTransaction } from '@quro/shared';
 import { TXN_META, TXN_TYPE_LIST } from '../constants';
 import type { SaveTransactionInput, TxnType } from '../types';
+import { saveSavingsTransaction } from '../utils/save-transaction';
 
 function toFiniteNumber(value: number): number {
   const normalized = Number(value);
@@ -22,7 +23,7 @@ type AddTxnModalProps = {
   account: SavingsAccount;
   existing?: SavingsTransaction;
   onClose: () => void;
-  onSave: (transaction: SaveTransactionInput) => void;
+  onSave: (transaction: SaveTransactionInput) => Promise<void>;
 };
 
 function signedAmount(type: TxnType, amount: number): number {
@@ -71,7 +72,7 @@ function BalancePreview({
 function useAddTxnForm(
   account: SavingsAccount,
   existing: SavingsTransaction | undefined,
-  onSave: (transaction: SaveTransactionInput) => void,
+  onSave: (transaction: SaveTransactionInput) => Promise<void>,
   onClose: () => void,
 ) {
   const [type, setType] = useState<TxnType>(existing?.type ?? 'deposit');
@@ -87,7 +88,7 @@ function useAddTxnForm(
     : 0;
   const balanceBeforeTxn = accountBalance - existingSignedAmount;
 
-  function handleSave(): void {
+  async function handleSave(): Promise<void> {
     if (!amount || isNaN(parsed) || parsed <= 0) {
       setError('Enter a valid amount');
       return;
@@ -97,8 +98,12 @@ function useAddTxnForm(
       return;
     }
     const payload = { accountId: account.id, type, amount: parsed, date, note };
-    onSave(existing ? { id: existing.id, ...payload } : payload);
-    onClose();
+    await saveSavingsTransaction({
+      transaction: existing ? { id: existing.id, ...payload } : payload,
+      onSave,
+      onClose,
+      setError,
+    });
   }
 
   return {
@@ -130,7 +135,9 @@ export function AddTxnModal({ account, existing, onClose, onSave }: AddTxnModalP
       footer={
         <ModalFooter
           onCancel={onClose}
-          onConfirm={form.handleSave}
+          onConfirm={() => {
+            void form.handleSave();
+          }}
           confirmLabel={isEditing ? 'Save Changes' : 'Record Transaction'}
         />
       }

--- a/packages/frontend/src/features/savings/components/SavingsModals.tsx
+++ b/packages/frontend/src/features/savings/components/SavingsModals.tsx
@@ -13,7 +13,7 @@ type SavingsModalsProps = {
   onSaveAccount: (account: SaveAccountInput) => Promise<void>;
   onDeleteAccount: (id: number, mode: DeleteSavingsAccountMode) => Promise<void>;
   onCloseTxnModal: () => void;
-  onSaveTxn: (transaction: SaveTransactionInput) => void;
+  onSaveTxn: (transaction: SaveTransactionInput) => Promise<void>;
 };
 
 export function SavingsModals({

--- a/packages/frontend/src/features/savings/utils/save-transaction.ts
+++ b/packages/frontend/src/features/savings/utils/save-transaction.ts
@@ -1,0 +1,22 @@
+import type { SaveTransactionInput } from '../types';
+
+type SaveSavingsTransactionParams = {
+  transaction: SaveTransactionInput;
+  onSave: (transaction: SaveTransactionInput) => Promise<void>;
+  onClose: () => void;
+  setError: (message: string) => void;
+};
+
+export async function saveSavingsTransaction({
+  transaction,
+  onSave,
+  onClose,
+  setError,
+}: SaveSavingsTransactionParams): Promise<void> {
+  try {
+    await onSave(transaction);
+    onClose();
+  } catch {
+    setError('Failed to save transaction. Please try again.');
+  }
+}


### PR DESCRIPTION
## Summary
- Makes the savings transaction modal await `onSave` before closing.
- Switches savings transaction create/update calls from `mutate()` to `mutateAsync()` so API failures propagate back to the modal.
- Keeps the modal open and shows `Failed to save transaction. Please try again.` when a save fails.
- Adds a regression test for the success/error save helper.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run format:check`
- [x] `bun run lint` (warnings only; existing `no-magic-numbers` warnings)
- [x] `bun run build`

Closes #136
