### PR TITLE
fix(investments): keep price updates with snapshot issues

### DIFF
--- a/packages/backend/src/lib/holdingPriceSync.test.ts
+++ b/packages/backend/src/lib/holdingPriceSync.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from 'bun:test';
+import { afterAll, describe, expect, mock, test } from 'bun:test';
 
 const holding = {
   id: 42,
@@ -24,6 +24,8 @@ const updatedHolding = {
 };
 
 let snapshotWriteShouldFail = false;
+
+const { db: realDb } = await import('../db/client');
 
 await mock.module('../db/client', () => ({
   db: {
@@ -67,6 +69,11 @@ await mock.module('./marketDataClient', () => ({
 }));
 
 const { syncHoldingPricesForUser } = await import('./holdingPriceSync');
+
+afterAll(async () => {
+  await mock.module('../db/client', () => ({ db: realDb }));
+  mock.restore();
+});
 
 describe('holding price sync', () => {
   test('reports a holding update even when the history snapshot write fails', async () => {

--- a/packages/backend/src/lib/holdingPriceSync.test.ts
+++ b/packages/backend/src/lib/holdingPriceSync.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+const holding = {
+  id: 42,
+  userId: 7,
+  name: 'Commonwealth Bank',
+  ticker: 'CBA',
+  currentPrice: 100,
+  currency: 'AUD' as const,
+  sector: 'Financials',
+  itemType: null,
+  exchangeMic: 'XASX',
+  industry: null,
+  priceUpdatedAt: null,
+  manualPrice: null,
+  excludeFromSync: false,
+  archivedAt: null,
+};
+
+const updatedHolding = {
+  ...holding,
+  currentPrice: 101.5,
+  priceUpdatedAt: new Date('2026-06-22T10:00:00.000Z'),
+};
+
+let snapshotWriteShouldFail = false;
+
+await mock.module('../db/client', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => Promise.resolve([holding]),
+      }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: () => ({
+          returning: () => Promise.resolve([updatedHolding]),
+        }),
+      }),
+    }),
+    insert: () => ({
+      values: () => ({
+        onConflictDoUpdate: () => {
+          if (snapshotWriteShouldFail) {
+            throw new Error('snapshot write failed');
+          }
+          return Promise.resolve();
+        },
+      }),
+    }),
+  },
+}));
+
+await mock.module('./marketDataClient', () => ({
+  getMarketDataClient: () => ({
+    getLatestEod: () =>
+      Promise.resolve({
+        'CBA.AX': {
+          close: 101.5,
+          priceCurrency: 'AUD',
+          eodDate: '2026-06-22',
+          tradeLast: '2026-06-22T10:00:00.000Z',
+        },
+      }),
+  }),
+}));
+
+const { syncHoldingPricesForUser } = await import('./holdingPriceSync');
+
+describe('holding price sync', () => {
+  test('reports a holding update even when the history snapshot write fails', async () => {
+    snapshotWriteShouldFail = true;
+
+    const outcome = await syncHoldingPricesForUser(holding.userId, { holdingIds: [holding.id] });
+
+    expect(outcome.updates).toHaveLength(1);
+    expect(outcome.updates[0]?.holding).toEqual(updatedHolding);
+    expect(outcome.summary.updatedHoldings).toBe(1);
+    expect(outcome.summary.skippedHoldings).toBe(0);
+    expect(outcome.summary.issues).toEqual([
+      {
+        holdingId: holding.id,
+        ticker: holding.ticker,
+        reason: 'Price updated, but failed to persist history snapshot',
+      },
+    ]);
+  });
+});

--- a/packages/backend/src/lib/holdingPriceSync.ts
+++ b/packages/backend/src/lib/holdingPriceSync.ts
@@ -282,16 +282,11 @@ export async function syncHoldingPricesForUser(
       quoteCheck.ticker,
       quoteCheck.quote,
     );
-    if ('issue' in updateResult && updateResult.issue !== undefined) {
-      issues.push(updateResult.issue);
-      continue;
-    }
-
-    if ('issue' in updateResult && updateResult.issue !== undefined) {
-      issues.push(updateResult.issue);
-    }
     if ('updated' in updateResult) {
       updates.push(updateResult.updated);
+    }
+    if ('issue' in updateResult && updateResult.issue !== undefined) {
+      issues.push(updateResult.issue);
     }
   }
 


### PR DESCRIPTION
## Summary
- Preserve successful holding price updates in sync results even when the history snapshot write fails.
- Keep snapshot persistence failures in the issues array so callers can surface the partial failure accurately.
- Add a regression test for the combined `updated` + `issue` result path.

Closes #151

## Test Plan
- [x] `bun run typecheck`
- [x] `bun run lint` (passes with existing warnings)
