### PR TITLE
test(bunq): cover signed OAuth state

### DIFF
--- a/packages/backend/src/routes/bunq.test.ts
+++ b/packages/backend/src/routes/bunq.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test';
+import { buildOAuthState, parseSignedState } from './bunq';
+
+function replaceSignature(state: string, signature: string): string {
+  const dotIdx = state.lastIndexOf('.');
+  return `${state.slice(0, dotIdx + 1)}${signature}`;
+}
+
+describe('bunq OAuth signed state', () => {
+  test('round-trips a signed state to its user id', () => {
+    const state = buildOAuthState(123, 'nonce-value');
+
+    expect(parseSignedState(state)).toBe(123);
+  });
+
+  test('rejects a tampered signature', () => {
+    const state = buildOAuthState(123, 'nonce-value');
+    const tampered = `${state.slice(0, -1)}${state.endsWith('0') ? '1' : '0'}`;
+
+    expect(parseSignedState(tampered)).toBeNull();
+  });
+
+  test('rejects a tampered payload with the original signature', () => {
+    const state = buildOAuthState(123, 'nonce-value');
+    const [, signature] = state.split('.');
+
+    expect(parseSignedState(`456:nonce-value.${signature}`)).toBeNull();
+  });
+
+  test('rejects malformed and non-integer payloads', () => {
+    expect(parseSignedState('state-without-signature')).toBeNull();
+    expect(parseSignedState(buildOAuthState(Number.NaN, 'nonce-value'))).toBeNull();
+  });
+
+  test('rejects signature buffers with mismatched lengths without throwing', () => {
+    const state = buildOAuthState(123, 'nonce-value');
+
+    expect(parseSignedState(replaceSignature(state, 'abcd'))).toBeNull();
+  });
+});

--- a/packages/backend/src/routes/bunq.ts
+++ b/packages/backend/src/routes/bunq.ts
@@ -21,7 +21,7 @@ const FRONTEND_SETTINGS_PATH = FRONTEND_ORIGIN
 
 const BUNQ_STATE_KEY = process.env.BUNQ_CLIENT_SECRET ?? '';
 
-function buildOAuthState(userId: number, nonce: string): string {
+export function buildOAuthState(userId: number, nonce: string): string {
   const payload = `${userId}:${nonce}`;
   const sig = createHmac('sha256', BUNQ_STATE_KEY).update(payload).digest('hex');
   return `${payload}.${sig}`;
@@ -30,7 +30,7 @@ function buildOAuthState(userId: number, nonce: string): string {
 // Verifies the HMAC signature on an OAuth `state` value and returns the user id
 // it was issued for, or null if the signature is invalid or malformed. This is
 // what authenticates the callback when it lands without a Quro session cookie.
-function parseSignedState(state: string): number | null {
+export function parseSignedState(state: string): number | null {
   const dotIdx = state.lastIndexOf('.');
   if (dotIdx === -1) return null;
   const payload = state.slice(0, dotIdx);


### PR DESCRIPTION
## Summary
- Export the bunq OAuth signed-state helpers for direct characterization tests.
- Add coverage for valid round trips, tampered signatures, tampered payloads, malformed states, non-integer user IDs, and mismatched signature buffer lengths.

Closes #139

## Test Plan
- [x] `bun run typecheck`
- [x] `bun run lint` (passes with existing warnings)
- [ ] `NODE_ENV=test bun test src/routes/bunq.test.ts` (blocked locally: Bun 1.3.14 crashes with SIGILL/segfault on this VM before executing tests)
