### PR TITLE
feat(fx): add historical rate history

### DIFF
--- a/packages/backend/src/db/migrations/0022_yellow_kitty_pryde.sql
+++ b/packages/backend/src/db/migrations/0022_yellow_kitty_pryde.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "currency_rate_history" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"from_currency" "currency_code" NOT NULL,
+	"to_currency" "currency_code" NOT NULL,
+	"rate" numeric(12, 6) NOT NULL,
+	"rate_date" date NOT NULL,
+	"provider" text NOT NULL,
+	"synced_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "currency_rate_history_from_to_date_unique" ON "currency_rate_history" USING btree ("from_currency","to_currency","rate_date");--> statement-breakpoint
+CREATE INDEX "currency_rate_history_from_to_date_idx" ON "currency_rate_history" USING btree ("from_currency","to_currency","rate_date");

--- a/packages/backend/src/db/migrations/meta/0022_snapshot.json
+++ b/packages/backend/src/db/migrations/meta/0022_snapshot.json
@@ -1,0 +1,4024 @@
+{
+  "id": "632c8492-7887-4fa1-a9d2-f6ad1fb47852",
+  "prevId": "d944f384-315d-44c6-baf6-3ac3d9729bd8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.budget_categories": {
+      "name": "budget_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budgeted": {
+          "name": "budgeted",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spent": {
+          "name": "spent",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "budget_categories_user_id_idx": {
+          "name": "budget_categories_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budget_categories_user_month_name_unique": {
+          "name": "budget_categories_user_month_name_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budget_categories_user_id_users_id_fk": {
+          "name": "budget_categories_user_id_users_id_fk",
+          "tableFrom": "budget_categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budget_transactions": {
+      "name": "budget_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bunq_transaction_id": {
+          "name": "bunq_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bunq_mcc": {
+          "name": "bunq_mcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bunq_payment_type": {
+          "name": "bunq_payment_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_provider": {
+          "name": "source_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_account_id": {
+          "name": "source_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_account_name": {
+          "name": "source_account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_account_type": {
+          "name": "source_account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_iban": {
+          "name": "counterparty_iban",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "budget_transactions_user_id_idx": {
+          "name": "budget_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budget_transactions_user_date_idx": {
+          "name": "budget_transactions_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budget_transactions_user_bunq_transaction_id_unique": {
+          "name": "budget_transactions_user_bunq_transaction_id_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bunq_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budget_transactions_user_id_users_id_fk": {
+          "name": "budget_transactions_user_id_users_id_fk",
+          "tableFrom": "budget_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "budget_transactions_category_id_budget_categories_id_fk": {
+          "name": "budget_transactions_category_id_budget_categories_id_fk",
+          "tableFrom": "budget_transactions",
+          "tableTo": "budget_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bunq_connections": {
+      "name": "bunq_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_token": {
+          "name": "installation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_public_key": {
+          "name": "server_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_expires_at": {
+          "name": "session_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bunq_user_id": {
+          "name": "bunq_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "bunq_sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bunq_connections_user_id_idx": {
+          "name": "bunq_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bunq_connections_user_id_users_id_fk": {
+          "name": "bunq_connections_user_id_users_id_fk",
+          "tableFrom": "bunq_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_mappings": {
+      "name": "category_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_name": {
+          "name": "category_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "category_mappings_user_id_idx": {
+          "name": "category_mappings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "category_mappings_user_source_key_unique": {
+          "name": "category_mappings_user_source_key_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "category_mappings_user_id_users_id_fk": {
+          "name": "category_mappings_user_id_users_id_fk",
+          "tableFrom": "category_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.currency_rate_history": {
+      "name": "currency_rate_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_currency": {
+          "name": "from_currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_currency": {
+          "name": "to_currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_date": {
+          "name": "rate_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "currency_rate_history_from_to_date_unique": {
+          "name": "currency_rate_history_from_to_date_unique",
+          "columns": [
+            {
+              "expression": "from_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rate_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "currency_rate_history_from_to_date_idx": {
+          "name": "currency_rate_history_from_to_date_idx",
+          "columns": [
+            {
+              "expression": "from_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rate_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.currency_rates": {
+      "name": "currency_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_currency": {
+          "name": "from_currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_currency": {
+          "name": "to_currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_date": {
+          "name": "source_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "currency_rates_from_to_unique": {
+          "name": "currency_rates_from_to_unique",
+          "columns": [
+            {
+              "expression": "from_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_transactions": {
+      "name": "dashboard_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dashboard_transactions_user_id_idx": {
+          "name": "dashboard_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboard_transactions_user_date_idx": {
+          "name": "dashboard_transactions_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboard_transactions_user_id_users_id_fk": {
+          "name": "dashboard_transactions_user_id_users_id_fk",
+          "tableFrom": "dashboard_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.debt_payments": {
+      "name": "debt_payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "debt_id": {
+          "name": "debt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal": {
+          "name": "principal",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest": {
+          "name": "interest",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "debt_payments_user_id_idx": {
+          "name": "debt_payments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "debt_payments_user_date_idx": {
+          "name": "debt_payments_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "debt_payments_debt_id_idx": {
+          "name": "debt_payments_debt_id_idx",
+          "columns": [
+            {
+              "expression": "debt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "debt_payments_user_id_users_id_fk": {
+          "name": "debt_payments_user_id_users_id_fk",
+          "tableFrom": "debt_payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "debt_payments_debt_id_debts_id_fk": {
+          "name": "debt_payments_debt_id_debts_id_fk",
+          "tableFrom": "debt_payments",
+          "tableTo": "debts",
+          "columnsFrom": [
+            "debt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.debts": {
+      "name": "debts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lender": {
+          "name": "lender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_amount": {
+          "name": "original_amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remaining_balance": {
+          "name": "remaining_balance",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest_rate": {
+          "name": "interest_rate",
+          "type": "numeric(7, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthly_payment": {
+          "name": "monthly_payment",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "debts_user_id_idx": {
+          "name": "debts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "debts_user_id_users_id_fk": {
+          "name": "debts_user_id_users_id_fk",
+          "tableFrom": "debts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_amount": {
+          "name": "current_amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_amount": {
+          "name": "target_amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthly_contribution": {
+          "name": "monthly_contribution",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthly_target": {
+          "name": "monthly_target",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "months_completed": {
+          "name": "months_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_months": {
+          "name": "total_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "start_month": {
+          "name": "start_month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "missed_months": {
+          "name": "missed_months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "goals_user_id_idx": {
+          "name": "goals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "goals_source_idx": {
+          "name": "goals_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "goals_user_id_users_id_fk": {
+          "name": "goals_user_id_users_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "goals_source_type_check": {
+          "name": "goals_source_type_check",
+          "value": "\"goals\".\"source_type\" in ('manual', 'salary_latest_gross', 'savings_account', 'portfolio_total', 'net_worth_total', 'invest_habit_buys')"
+        },
+        "goals_source_id_check": {
+          "name": "goals_source_id_check",
+          "value": "((\"goals\".\"source_type\" = 'savings_account' and \"goals\".\"source_id\" is not null and \"goals\".\"source_id\" > 0) or (\"goals\".\"source_type\" <> 'savings_account' and \"goals\".\"source_id\" is null))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.holding_price_history": {
+      "name": "holding_price_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "holding_id": {
+          "name": "holding_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eod_date": {
+          "name": "eod_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "close_price": {
+          "name": "close_price",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_currency": {
+          "name": "price_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "holding_price_history_user_date_idx": {
+          "name": "holding_price_history_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eod_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "holding_price_history_holding_date_idx": {
+          "name": "holding_price_history_holding_date_idx",
+          "columns": [
+            {
+              "expression": "holding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eod_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "holding_price_history_holding_date_unique": {
+          "name": "holding_price_history_holding_date_unique",
+          "columns": [
+            {
+              "expression": "holding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eod_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "holding_price_history_user_id_users_id_fk": {
+          "name": "holding_price_history_user_id_users_id_fk",
+          "tableFrom": "holding_price_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "holding_price_history_holding_id_holdings_id_fk": {
+          "name": "holding_price_history_holding_id_holdings_id_fk",
+          "tableFrom": "holding_price_history",
+          "tableTo": "holdings",
+          "columnsFrom": [
+            "holding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.holding_transactions": {
+      "name": "holding_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "holding_id": {
+          "name": "holding_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shares": {
+          "name": "shares",
+          "type": "numeric(19, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "holding_transactions_user_id_idx": {
+          "name": "holding_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "holding_transactions_user_date_idx": {
+          "name": "holding_transactions_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "holding_transactions_user_id_users_id_fk": {
+          "name": "holding_transactions_user_id_users_id_fk",
+          "tableFrom": "holding_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "holding_transactions_holding_id_holdings_id_fk": {
+          "name": "holding_transactions_holding_id_holdings_id_fk",
+          "tableFrom": "holding_transactions",
+          "tableTo": "holdings",
+          "columnsFrom": [
+            "holding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.holdings": {
+      "name": "holdings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_price": {
+          "name": "current_price",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sector": {
+          "name": "sector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_mic": {
+          "name": "exchange_mic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industry": {
+          "name": "industry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_updated_at": {
+          "name": "price_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_price": {
+          "name": "manual_price",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclude_from_sync": {
+          "name": "exclude_from_sync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "holdings_user_id_idx": {
+          "name": "holdings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "holdings_user_id_users_id_fk": {
+          "name": "holdings_user_id_users_id_fk",
+          "tableFrom": "holdings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mortgage_transactions": {
+      "name": "mortgage_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mortgage_id": {
+          "name": "mortgage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest": {
+          "name": "interest",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal": {
+          "name": "principal",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fixed_years": {
+          "name": "fixed_years",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mortgage_transactions_user_id_idx": {
+          "name": "mortgage_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mortgage_transactions_user_date_idx": {
+          "name": "mortgage_transactions_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mortgage_transactions_user_id_users_id_fk": {
+          "name": "mortgage_transactions_user_id_users_id_fk",
+          "tableFrom": "mortgage_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "mortgage_transactions_mortgage_id_mortgages_id_fk": {
+          "name": "mortgage_transactions_mortgage_id_mortgages_id_fk",
+          "tableFrom": "mortgage_transactions",
+          "tableTo": "mortgages",
+          "columnsFrom": [
+            "mortgage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mortgages": {
+      "name": "mortgages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_address": {
+          "name": "property_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lender": {
+          "name": "lender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_amount": {
+          "name": "original_amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outstanding_balance": {
+          "name": "outstanding_balance",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_value": {
+          "name": "property_value",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthly_payment": {
+          "name": "monthly_payment",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest_rate": {
+          "name": "interest_rate",
+          "type": "numeric(7, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_type": {
+          "name": "rate_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fixed_until": {
+          "name": "fixed_until",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "term_years": {
+          "name": "term_years",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overpayment_limit": {
+          "name": "overpayment_limit",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_joint": {
+          "name": "is_joint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mortgages_user_id_idx": {
+          "name": "mortgages_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mortgages_user_id_users_id_fk": {
+          "name": "mortgages_user_id_users_id_fk",
+          "tableFrom": "mortgages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_links": {
+      "name": "partner_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addressee_id": {
+          "name": "addressee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "partner_link_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "partner_links_requester_id_unique": {
+          "name": "partner_links_requester_id_unique",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_links_addressee_id_unique": {
+          "name": "partner_links_addressee_id_unique",
+          "columns": [
+            {
+              "expression": "addressee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partner_links_requester_id_users_id_fk": {
+          "name": "partner_links_requester_id_users_id_fk",
+          "tableFrom": "partner_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "partner_links_addressee_id_users_id_fk": {
+          "name": "partner_links_addressee_id_users_id_fk",
+          "tableFrom": "partner_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addressee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "partner_links_no_self_link_check": {
+          "name": "partner_links_no_self_link_check",
+          "value": "\"partner_links\".\"requester_id\" <> \"partner_links\".\"addressee_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.payslips": {
+      "name": "payslips",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gross": {
+          "name": "gross",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pension": {
+          "name": "pension",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "net": {
+          "name": "net",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bonus": {
+          "name": "bonus",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "document_storage_key": {
+          "name": "document_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_file_name": {
+          "name": "document_file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_size_bytes": {
+          "name": "document_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_uploaded_at": {
+          "name": "document_uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payslips_user_id_idx": {
+          "name": "payslips_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payslips_user_date_idx": {
+          "name": "payslips_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payslips_user_id_users_id_fk": {
+          "name": "payslips_user_id_users_id_fk",
+          "tableFrom": "payslips",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "payslips_document_fields_chk": {
+          "name": "payslips_document_fields_chk",
+          "value": "((\"payslips\".\"document_storage_key\" is null and \"payslips\".\"document_file_name\" is null and \"payslips\".\"document_size_bytes\" is null and \"payslips\".\"document_uploaded_at\" is null) or (\"payslips\".\"document_storage_key\" is not null and \"payslips\".\"document_file_name\" is not null and \"payslips\".\"document_size_bytes\" is not null and \"payslips\".\"document_uploaded_at\" is not null))"
+        },
+        "payslips_document_size_bytes_chk": {
+          "name": "payslips_document_size_bytes_chk",
+          "value": "\"payslips\".\"document_size_bytes\" is null or \"payslips\".\"document_size_bytes\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pension_pots": {
+      "name": "pension_pots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employee_monthly": {
+          "name": "employee_monthly",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employer_monthly": {
+          "name": "employer_monthly",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investment_strategy": {
+          "name": "investment_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pension_pots_user_id_idx": {
+          "name": "pension_pots_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pension_pots_user_id_users_id_fk": {
+          "name": "pension_pots_user_id_users_id_fk",
+          "tableFrom": "pension_pots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pension_statement_import_rows": {
+      "name": "pension_statement_import_rows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "import_id": {
+          "name": "import_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_order": {
+          "name": "row_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_employer": {
+          "name": "is_employer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "confidence_label": {
+          "name": "confidence_label",
+          "type": "pension_import_confidence_label",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'low'"
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_derived": {
+          "name": "is_derived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "collision_warning": {
+          "name": "collision_warning",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_transaction_id": {
+          "name": "committed_transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pension_statement_import_rows_import_order_idx": {
+          "name": "pension_statement_import_rows_import_order_idx",
+          "columns": [
+            {
+              "expression": "import_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "row_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pension_statement_import_rows_import_deleted_idx": {
+          "name": "pension_statement_import_rows_import_deleted_idx",
+          "columns": [
+            {
+              "expression": "import_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pension_statement_import_rows_committed_txn_idx": {
+          "name": "pension_statement_import_rows_committed_txn_idx",
+          "columns": [
+            {
+              "expression": "committed_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pension_statement_import_rows_import_id_pension_statement_imports_id_fk": {
+          "name": "pension_statement_import_rows_import_id_pension_statement_imports_id_fk",
+          "tableFrom": "pension_statement_import_rows",
+          "tableTo": "pension_statement_imports",
+          "columnsFrom": [
+            "import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pension_statement_import_rows_committed_transaction_id_pension_transactions_id_fk": {
+          "name": "pension_statement_import_rows_committed_transaction_id_pension_transactions_id_fk",
+          "tableFrom": "pension_statement_import_rows",
+          "tableTo": "pension_transactions",
+          "columnsFrom": [
+            "committed_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pension_statement_imports": {
+      "name": "pension_statement_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pot_id": {
+          "name": "pot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pension_import_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash_sha256": {
+          "name": "file_hash_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement_period_start": {
+          "name": "statement_period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_period_end": {
+          "name": "statement_period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language_hints": {
+          "name": "language_hints",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pension_statement_imports_user_status_idx": {
+          "name": "pension_statement_imports_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pension_statement_imports_pot_id_idx": {
+          "name": "pension_statement_imports_pot_id_idx",
+          "columns": [
+            {
+              "expression": "pot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pension_statement_imports_hash_idx": {
+          "name": "pension_statement_imports_hash_idx",
+          "columns": [
+            {
+              "expression": "file_hash_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pension_statement_imports_user_id_users_id_fk": {
+          "name": "pension_statement_imports_user_id_users_id_fk",
+          "tableFrom": "pension_statement_imports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pension_statement_imports_pot_id_pension_pots_id_fk": {
+          "name": "pension_statement_imports_pot_id_pension_pots_id_fk",
+          "tableFrom": "pension_statement_imports",
+          "tableTo": "pension_pots",
+          "columnsFrom": [
+            "pot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pension_transactions": {
+      "name": "pension_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pot_id": {
+          "name": "pot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_employer": {
+          "name": "is_employer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_storage_key": {
+          "name": "document_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_file_name": {
+          "name": "document_file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_size_bytes": {
+          "name": "document_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_uploaded_at": {
+          "name": "document_uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pension_transactions_user_id_idx": {
+          "name": "pension_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pension_transactions_user_date_idx": {
+          "name": "pension_transactions_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pension_transactions_user_id_users_id_fk": {
+          "name": "pension_transactions_user_id_users_id_fk",
+          "tableFrom": "pension_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pension_transactions_pot_id_pension_pots_id_fk": {
+          "name": "pension_transactions_pot_id_pension_pots_id_fk",
+          "tableFrom": "pension_transactions",
+          "tableTo": "pension_pots",
+          "columnsFrom": [
+            "pot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pension_transactions_document_fields_chk": {
+          "name": "pension_transactions_document_fields_chk",
+          "value": "((\"pension_transactions\".\"document_storage_key\" is null and \"pension_transactions\".\"document_file_name\" is null and \"pension_transactions\".\"document_size_bytes\" is null and \"pension_transactions\".\"document_uploaded_at\" is null) or (\"pension_transactions\".\"document_storage_key\" is not null and \"pension_transactions\".\"document_file_name\" is not null and \"pension_transactions\".\"document_size_bytes\" is not null and \"pension_transactions\".\"document_uploaded_at\" is not null))"
+        },
+        "pension_transactions_document_size_bytes_chk": {
+          "name": "pension_transactions_document_size_bytes_chk",
+          "value": "\"pension_transactions\".\"document_size_bytes\" is null or \"pension_transactions\".\"document_size_bytes\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.properties": {
+      "name": "properties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_type": {
+          "name": "property_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mortgage": {
+          "name": "mortgage",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mortgage_id": {
+          "name": "mortgage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_rent": {
+          "name": "monthly_rent",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_joint": {
+          "name": "is_joint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "properties_user_id_idx": {
+          "name": "properties_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_mortgage_id_idx": {
+          "name": "properties_mortgage_id_idx",
+          "columns": [
+            {
+              "expression": "mortgage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "properties_user_id_users_id_fk": {
+          "name": "properties_user_id_users_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "properties_mortgage_id_mortgages_id_fk": {
+          "name": "properties_mortgage_id_mortgages_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "mortgages",
+          "columnsFrom": [
+            "mortgage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.property_transactions": {
+      "name": "property_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest": {
+          "name": "interest",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal": {
+          "name": "principal",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "property_transactions_user_id_idx": {
+          "name": "property_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "property_transactions_user_date_idx": {
+          "name": "property_transactions_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "property_transactions_user_id_users_id_fk": {
+          "name": "property_transactions_user_id_users_id_fk",
+          "tableFrom": "property_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "property_transactions_property_id_properties_id_fk": {
+          "name": "property_transactions_property_id_properties_id_fk",
+          "tableFrom": "property_transactions",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.savings_accounts": {
+      "name": "savings_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bank": {
+          "name": "bank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest_rate": {
+          "name": "interest_rate",
+          "type": "numeric(7, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bunq_account_id": {
+          "name": "bunq_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_joint": {
+          "name": "is_joint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "savings_accounts_user_id_idx": {
+          "name": "savings_accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "savings_accounts_user_bunq_account_id_unique": {
+          "name": "savings_accounts_user_bunq_account_id_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bunq_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "savings_accounts_user_id_users_id_fk": {
+          "name": "savings_accounts_user_id_users_id_fk",
+          "tableFrom": "savings_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.savings_transactions": {
+      "name": "savings_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(19, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bunq_transaction_id": {
+          "name": "bunq_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "savings_transactions_user_id_idx": {
+          "name": "savings_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "savings_transactions_user_date_idx": {
+          "name": "savings_transactions_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "savings_transactions_user_bunq_transaction_id_unique": {
+          "name": "savings_transactions_user_bunq_transaction_id_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bunq_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "savings_transactions_user_id_users_id_fk": {
+          "name": "savings_transactions_user_id_users_id_fk",
+          "tableFrom": "savings_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "savings_transactions_account_id_savings_accounts_id_fk": {
+          "name": "savings_transactions_account_id_savings_accounts_id_fk",
+          "tableFrom": "savings_transactions",
+          "tableTo": "savings_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stock_exchanges": {
+      "name": "stock_exchanges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mic": {
+          "name": "mic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acronym": {
+          "name": "acronym",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stock_exchanges_mic_unique": {
+          "name": "stock_exchanges_mic_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mic"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 35
+        },
+        "retirement_age": {
+          "name": "retirement_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 67
+        },
+        "base_currency": {
+          "name": "base_currency",
+          "type": "currency_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "number_format": {
+          "name": "number_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en-US'"
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_updated_at": {
+          "name": "password_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_age_range_check": {
+          "name": "users_age_range_check",
+          "value": "\"users\".\"age\" between 16 and 100"
+        },
+        "users_retirement_age_range_check": {
+          "name": "users_retirement_age_range_check",
+          "value": "\"users\".\"retirement_age\" between 17 and 80"
+        },
+        "users_retirement_after_age_check": {
+          "name": "users_retirement_after_age_check",
+          "value": "\"users\".\"retirement_age\" > \"users\".\"age\""
+        },
+        "users_number_format_check": {
+          "name": "users_number_format_check",
+          "value": "\"users\".\"number_format\" in ('en-US', 'de-DE')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.worker_heartbeats": {
+      "name": "worker_heartbeats",
+      "schema": "",
+      "columns": {
+        "worker_name": {
+          "name": "worker_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parser_healthy": {
+          "name": "parser_healthy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "parser_checked_at": {
+          "name": "parser_checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parser_error": {
+          "name": "parser_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.bunq_sync_status": {
+      "name": "bunq_sync_status",
+      "schema": "public",
+      "values": [
+        "idle",
+        "syncing",
+        "error"
+      ]
+    },
+    "public.currency_code": {
+      "name": "currency_code",
+      "schema": "public",
+      "values": [
+        "EUR",
+        "GBP",
+        "USD",
+        "AUD",
+        "NZD",
+        "CAD",
+        "CHF",
+        "SGD"
+      ]
+    },
+    "public.partner_link_status": {
+      "name": "partner_link_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted"
+      ]
+    },
+    "public.pension_import_confidence_label": {
+      "name": "pension_import_confidence_label",
+      "schema": "public",
+      "values": [
+        "high",
+        "medium",
+        "low"
+      ]
+    },
+    "public.pension_import_status": {
+      "name": "pension_import_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "processing",
+        "ready_for_review",
+        "failed",
+        "committed",
+        "expired",
+        "cancelled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/backend/src/db/migrations/meta/_journal.json
+++ b/packages/backend/src/db/migrations/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1782121341796,
       "tag": "0021_careful_micromax",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1782132357333,
+      "tag": "0022_yellow_kitty_pryde",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/src/db/numericWireContract.test.ts
+++ b/packages/backend/src/db/numericWireContract.test.ts
@@ -22,7 +22,7 @@ describe('numeric wire contract', () => {
     expect(schemaSource).toContain('fromDriver(value)');
     expect(schemaSource).toContain('return Number.isFinite(parsed) ? parsed : 0;');
     expect(schemaSource).not.toMatch(/\bnumeric\s*,/);
-    expect(schemaSource.match(/numericAsNumber\(/g)).toHaveLength(54);
+    expect(schemaSource.match(/numericAsNumber\(/g)).toHaveLength(55);
   });
 
   test('does not reintroduce frontend numeric API response coercion helpers', () => {

--- a/packages/backend/src/db/schema.ts
+++ b/packages/backend/src/db/schema.ts
@@ -826,6 +826,31 @@ export const currencyRates = pgTable(
   }),
 );
 
+export const currencyRateHistory = pgTable(
+  'currency_rate_history',
+  {
+    id: serial('id').primaryKey(),
+    fromCurrency: currencyCodeEnum('from_currency').notNull(),
+    toCurrency: currencyCodeEnum('to_currency').notNull(),
+    rate: numericAsNumber('rate', { precision: 12, scale: 6 }).notNull(),
+    rateDate: date('rate_date', { mode: 'string' }).notNull(),
+    provider: text('provider').notNull(),
+    syncedAt: timestamp('synced_at').defaultNow().notNull(),
+  },
+  (table) => ({
+    fromToDateUnique: uniqueIndex('currency_rate_history_from_to_date_unique').on(
+      table.fromCurrency,
+      table.toCurrency,
+      table.rateDate,
+    ),
+    fromToDateIdx: index('currency_rate_history_from_to_date_idx').on(
+      table.fromCurrency,
+      table.toCurrency,
+      table.rateDate,
+    ),
+  }),
+);
+
 // ── Dashboard ────────────────────────────────────────────────────────────────
 
 export const dashboardTransactions = pgTable(

--- a/packages/backend/src/lib/currencyRateHistory.test.ts
+++ b/packages/backend/src/lib/currencyRateHistory.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  buildHistoricalCurrencyRateResolver,
+  type HistoricalCurrencyRateRow,
+} from './currencyRateHistory';
+
+const CURRENT_RATES = new Map<string, number>([
+  ['EUR', 1],
+  ['GBP', 1.2],
+  ['USD', 0.9],
+]);
+
+function buildRate(overrides: Partial<HistoricalCurrencyRateRow>): HistoricalCurrencyRateRow {
+  return {
+    fromCurrency: 'GBP',
+    toCurrency: 'EUR',
+    rate: 1.1,
+    rateDate: '2025-01-31',
+    provider: 'fixture',
+    syncedAt: new Date('2026-01-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('historical currency rate resolver', () => {
+  test('uses the nearest previous historical rate for dated conversion', () => {
+    const resolver = buildHistoricalCurrencyRateResolver(
+      [
+        buildRate({ rate: 1.05, rateDate: '2025-01-31' }),
+        buildRate({ rate: 1.15, rateDate: '2025-03-31' }),
+      ],
+      CURRENT_RATES,
+    );
+
+    const conversion = resolver.convertToBase(100, 'GBP', '2025-04-15');
+
+    expect(conversion).toEqual({
+      value: 114.99999999999999,
+      rateDate: '2025-03-31',
+      estimated: true,
+    });
+    expect(resolver.getCoverage()).toEqual({
+      missingCurrencies: [],
+      estimatedDates: ['2025-04-15'],
+    });
+  });
+
+  test('falls back to the current rate and marks coverage when history is missing', () => {
+    const resolver = buildHistoricalCurrencyRateResolver([], CURRENT_RATES);
+
+    const conversion = resolver.convertToBase(100, 'USD', '2025-04-15');
+
+    expect(conversion).toEqual({ value: 90, rateDate: null, estimated: true });
+    expect(resolver.getCoverage()).toEqual({
+      missingCurrencies: ['USD'],
+      estimatedDates: ['2025-04-15'],
+    });
+  });
+});

--- a/packages/backend/src/lib/currencyRateHistory.ts
+++ b/packages/backend/src/lib/currencyRateHistory.ts
@@ -1,0 +1,133 @@
+import { asc } from 'drizzle-orm';
+import { type CurrencyCode } from '@quro/shared';
+import { db } from '../db/client';
+import { currencyRateHistory } from '../db/schema';
+import { convertToBaseCurrency, FX_BASE_CURRENCY } from './currencyRateCache';
+
+const DATE_PART_LENGTH = 10;
+
+export type HistoricalCurrencyRateRow = {
+  fromCurrency: CurrencyCode;
+  toCurrency: CurrencyCode;
+  rate: number;
+  rateDate: string;
+  provider: string;
+  syncedAt: Date;
+};
+
+export type DatedCurrencyConversion = {
+  value: number;
+  rateDate: string | null;
+  estimated: boolean;
+};
+
+export type HistoricalRateCoverage = {
+  missingCurrencies: string[];
+  estimatedDates: string[];
+};
+
+export type HistoricalCurrencyRateResolver = {
+  convertToBase: (amount: number, currency: string, date: string | Date) => DatedCurrencyConversion;
+  getCoverage: () => HistoricalRateCoverage;
+};
+
+function toDateOnly(value: string | Date): string {
+  if (value instanceof Date) return value.toISOString().slice(0, DATE_PART_LENGTH);
+  return value.slice(0, DATE_PART_LENGTH);
+}
+
+function toRateKey(fromCurrency: string, toCurrency: string): string {
+  return `${fromCurrency}:${toCurrency}`;
+}
+
+function buildRowsByPair(
+  rows: readonly HistoricalCurrencyRateRow[],
+): Map<string, HistoricalCurrencyRateRow[]> {
+  const rowsByPair = new Map<string, HistoricalCurrencyRateRow[]>();
+  for (const row of rows) {
+    const key = toRateKey(row.fromCurrency, row.toCurrency);
+    const bucket = rowsByPair.get(key);
+    if (bucket) bucket.push(row);
+    else rowsByPair.set(key, [row]);
+  }
+
+  for (const bucket of rowsByPair.values()) {
+    bucket.sort((left, right) => left.rateDate.localeCompare(right.rateDate));
+  }
+
+  return rowsByPair;
+}
+
+function findNearestPreviousRow(
+  rows: readonly HistoricalCurrencyRateRow[],
+  date: string,
+): HistoricalCurrencyRateRow | null {
+  let selected: HistoricalCurrencyRateRow | null = null;
+  for (const row of rows) {
+    if (row.rateDate > date) break;
+    selected = row;
+  }
+  return selected;
+}
+
+export function buildHistoricalCurrencyRateResolver(
+  rows: readonly HistoricalCurrencyRateRow[],
+  currentRates: ReadonlyMap<string, number>,
+  baseCurrency: CurrencyCode = FX_BASE_CURRENCY,
+): HistoricalCurrencyRateResolver {
+  const rowsByPair = buildRowsByPair(rows);
+  const missingCurrencies = new Set<string>();
+  const estimatedDates = new Set<string>();
+
+  function convertToBase(
+    amount: number,
+    currency: string,
+    date: string | Date,
+  ): DatedCurrencyConversion {
+    if (currency === baseCurrency)
+      return { value: amount, rateDate: toDateOnly(date), estimated: false };
+
+    const dateOnly = toDateOnly(date);
+    const historicalRows = rowsByPair.get(toRateKey(currency, baseCurrency)) ?? [];
+    const historicalRate = findNearestPreviousRow(historicalRows, dateOnly);
+    if (historicalRate) {
+      if (historicalRate.rateDate !== dateOnly) estimatedDates.add(dateOnly);
+      return {
+        value: amount * historicalRate.rate,
+        rateDate: historicalRate.rateDate,
+        estimated: historicalRate.rateDate !== dateOnly,
+      };
+    }
+
+    const fallbackValue = convertToBaseCurrency(amount, currency, currentRates, baseCurrency);
+    missingCurrencies.add(currency);
+    estimatedDates.add(dateOnly);
+    return { value: fallbackValue, rateDate: null, estimated: true };
+  }
+
+  return {
+    convertToBase,
+    getCoverage: () => ({
+      missingCurrencies: [...missingCurrencies].sort(),
+      estimatedDates: [...estimatedDates].sort(),
+    }),
+  };
+}
+
+export function loadHistoricalCurrencyRateRows(): Promise<HistoricalCurrencyRateRow[]> {
+  return db
+    .select({
+      fromCurrency: currencyRateHistory.fromCurrency,
+      toCurrency: currencyRateHistory.toCurrency,
+      rate: currencyRateHistory.rate,
+      rateDate: currencyRateHistory.rateDate,
+      provider: currencyRateHistory.provider,
+      syncedAt: currencyRateHistory.syncedAt,
+    })
+    .from(currencyRateHistory)
+    .orderBy(
+      asc(currencyRateHistory.fromCurrency),
+      asc(currencyRateHistory.toCurrency),
+      asc(currencyRateHistory.rateDate),
+    );
+}

--- a/packages/backend/src/lib/currencyRateSync.ts
+++ b/packages/backend/src/lib/currencyRateSync.ts
@@ -1,7 +1,7 @@
 import { CURRENCY_CODES, type CurrencyCode } from '@quro/shared';
 import { asc, sql } from 'drizzle-orm';
 import { db } from '../db/client';
-import { currencyRates } from '../db/schema';
+import { currencyRateHistory, currencyRates } from '../db/schema';
 import {
   buildRatesToBaseCurrency,
   CurrencyRatesUnavailableError,
@@ -177,27 +177,54 @@ export async function syncCurrencyRates(
   const result = await fetchRates(baseCurrency, fromCurrencies);
 
   if (result.rates.length > 0) {
-    await db
-      .insert(currencyRates)
-      .values(
-        result.rates.map((rate) => ({
-          fromCurrency: rate.fromCurrency,
-          toCurrency: rate.toCurrency,
-          rate: rate.rate,
-          provider: rate.provider,
-          sourceDate: rate.sourceDate,
-          updatedAt: syncedAt,
-        })),
-      )
-      .onConflictDoUpdate({
-        target: [currencyRates.fromCurrency, currencyRates.toCurrency],
-        set: {
-          rate: sql`excluded.rate`,
-          provider: sql`excluded.provider`,
-          sourceDate: sql`excluded.source_date`,
-          updatedAt: sql`excluded.updated_at`,
-        },
-      });
+    await db.transaction(async (tx) => {
+      const rateRows = result.rates.map((rate) => ({
+        fromCurrency: rate.fromCurrency,
+        toCurrency: rate.toCurrency,
+        rate: rate.rate,
+        provider: rate.provider,
+        sourceDate: rate.sourceDate,
+        updatedAt: syncedAt,
+      }));
+
+      await tx
+        .insert(currencyRates)
+        .values(rateRows)
+        .onConflictDoUpdate({
+          target: [currencyRates.fromCurrency, currencyRates.toCurrency],
+          set: {
+            rate: sql`excluded.rate`,
+            provider: sql`excluded.provider`,
+            sourceDate: sql`excluded.source_date`,
+            updatedAt: sql`excluded.updated_at`,
+          },
+        });
+
+      await tx
+        .insert(currencyRateHistory)
+        .values(
+          rateRows.map((rate) => ({
+            fromCurrency: rate.fromCurrency,
+            toCurrency: rate.toCurrency,
+            rate: rate.rate,
+            rateDate: rate.sourceDate,
+            provider: rate.provider,
+            syncedAt,
+          })),
+        )
+        .onConflictDoUpdate({
+          target: [
+            currencyRateHistory.fromCurrency,
+            currencyRateHistory.toCurrency,
+            currencyRateHistory.rateDate,
+          ],
+          set: {
+            rate: sql`excluded.rate`,
+            provider: sql`excluded.provider`,
+            syncedAt: sql`excluded.synced_at`,
+          },
+        });
+    });
   }
 
   return {

--- a/packages/backend/src/routes/dashboard.test.ts
+++ b/packages/backend/src/routes/dashboard.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { buildHistoricalCurrencyRateResolver } from '../lib/currencyRateHistory';
 import { buildActivityList, buildNetWorthHistory, computeDerivedAllocations } from './dashboard';
 
 describe('dashboard debt integration helpers', () => {
@@ -86,6 +87,7 @@ describe('dashboard debt integration helpers', () => {
     const todayIso = today.toISOString().slice(0, 10);
     const history = buildNetWorthHistory({
       rates: new Map([['EUR', 1]]),
+      historicalRateResolver: buildHistoricalCurrencyRateResolver([], new Map([['EUR', 1]])),
       savings: [{ id: 1, balance: '1500', currency: 'EUR' }] as any,
       savingsTransactions: [] as any,
       holdings: [] as any,

--- a/packages/backend/src/routes/dashboard.ts
+++ b/packages/backend/src/routes/dashboard.ts
@@ -19,6 +19,11 @@ import {
 } from '../db/schema';
 import { getAuthUser } from '../lib/authUser';
 import { convertToBaseCurrency, FX_BASE_CURRENCY } from '../lib/currencyRateCache';
+import {
+  buildHistoricalCurrencyRateResolver,
+  loadHistoricalCurrencyRateRows,
+  type HistoricalCurrencyRateResolver,
+} from '../lib/currencyRateHistory';
 import { getCurrentRatesToBaseCurrency } from '../lib/currencyRateSync';
 import { getAcceptedPartnerId, ownedOrJointPredicate } from '../lib/partner';
 
@@ -73,6 +78,13 @@ function getRatesToBaseCurrency(): Promise<Map<string, number>> {
 const convertToBase = (amount: number, currency: string, rates: Map<string, number>) => {
   return convertToBaseCurrency(amount, currency, rates);
 };
+
+const convertHistoricalToBase = (
+  amount: number,
+  currency: string,
+  cutoff: number,
+  resolver: HistoricalCurrencyRateResolver,
+) => resolver.convertToBase(amount, currency, new Date(cutoff)).value;
 
 type DerivedAllocation = {
   id: number;
@@ -451,7 +463,7 @@ function computeDebtLiabilitiesAtCutoff(
   debts: readonly DebtRow[],
   paymentsByDebtId: ReadonlyMap<number, readonly DatedDebtPayment[]>,
   cutoff: number,
-  rates: Map<string, number>,
+  resolver: HistoricalCurrencyRateResolver,
 ): number {
   return debts.reduce((sum, debt) => {
     if (isArchivedAtCutoff(debt, cutoff)) return sum;
@@ -460,7 +472,7 @@ function computeDebtLiabilitiesAtCutoff(
       if (payment.timestamp <= cutoff) continue;
       balance += payment.principal;
     }
-    return sum + convertToBase(Math.max(0, balance), debt.currency, rates);
+    return sum + convertHistoricalToBase(Math.max(0, balance), debt.currency, cutoff, resolver);
   }, 0);
 }
 
@@ -583,7 +595,7 @@ function computeSavingsAtCutoff(
   accounts: readonly HistoricalSavingsAccountRow[],
   txnsByAccountId: ReadonlyMap<number, readonly DatedSavingsTransaction[]>,
   cutoff: number,
-  rates: Map<string, number>,
+  resolver: HistoricalCurrencyRateResolver,
 ): number {
   return accounts.reduce((sum, account) => {
     if (isArchivedAtCutoff(account, cutoff)) return sum;
@@ -594,7 +606,7 @@ function computeSavingsAtCutoff(
       if (transaction.type === 'withdrawal') balance += transaction.amount;
       else balance -= transaction.amount;
     }
-    return sum + convertToBase(Math.max(0, balance), account.currency, rates);
+    return sum + convertHistoricalToBase(Math.max(0, balance), account.currency, cutoff, resolver);
   }, 0);
 }
 
@@ -607,7 +619,7 @@ function computePensionAtCutoff(
   pots: readonly PensionPotRow[],
   txnsByPotId: ReadonlyMap<number, readonly DatedPensionTransaction[]>,
   cutoff: number,
-  rates: Map<string, number>,
+  resolver: HistoricalCurrencyRateResolver,
 ): number {
   return pots.reduce((sum, pot) => {
     if (isArchivedAtCutoff(pot, cutoff)) return sum;
@@ -616,7 +628,7 @@ function computePensionAtCutoff(
       if (transaction.timestamp <= cutoff) continue;
       balance -= computePensionTxnDelta(transaction);
     }
-    return sum + convertToBase(Math.max(0, balance), pot.currency, rates);
+    return sum + convertHistoricalToBase(Math.max(0, balance), pot.currency, cutoff, resolver);
   }, 0);
 }
 
@@ -624,7 +636,7 @@ function computeBrokerageAtCutoff(
   portfolioHoldings: readonly HoldingRow[],
   txnsByHoldingId: ReadonlyMap<number, readonly DatedHoldingTransaction[]>,
   cutoff: number,
-  rates: Map<string, number>,
+  resolver: HistoricalCurrencyRateResolver,
 ): number {
   return portfolioHoldings.reduce((sum, holding) => {
     if (isArchivedAtCutoff(holding, cutoff)) return sum;
@@ -635,7 +647,7 @@ function computeBrokerageAtCutoff(
       else shares -= transaction.shares;
     }
     const value = Math.max(0, shares) * toNumber(holding.currentPrice);
-    return sum + convertToBase(value, holding.currency, rates);
+    return sum + convertHistoricalToBase(value, holding.currency, cutoff, resolver);
   }, 0);
 }
 
@@ -656,7 +668,7 @@ function computePropertyEquityAtCutoff(
   txnsByPropertyId: ReadonlyMap<number, readonly DatedPropertyTransaction[]>,
   mortgageBalanceById: ReadonlyMap<number, number>,
   cutoff: number,
-  rates: Map<string, number>,
+  resolver: HistoricalCurrencyRateResolver,
 ): number {
   function resolvePropertyValueAtCutoff(
     property: PropertyRow,
@@ -703,12 +715,13 @@ function computePropertyEquityAtCutoff(
     const propertyValue = resolvePropertyValueAtCutoff(property, transactions);
     const mortgageBalance = resolveMortgageBalanceAtCutoff(property, transactions);
     const equity = propertyValue - mortgageBalance;
-    return sum + convertToBase(equity, property.currency, rates);
+    return sum + convertHistoricalToBase(equity, property.currency, cutoff, resolver);
   }, 0);
 }
 
 type NetWorthSourceData = {
   rates: Map<string, number>;
+  historicalRateResolver: HistoricalCurrencyRateResolver;
   savings: HistoricalSavingsAccountRow[];
   savingsTransactions: SavingsTransactionRow[];
   holdings: HoldingRow[];
@@ -728,6 +741,7 @@ type NetWorthHistoryPoint = {
   year: number;
   totalValue: number;
   currency: string;
+  fxEstimated: boolean;
 };
 
 async function safeLoad<T>(label: string, query: Promise<T>, fallback: T): Promise<T> {
@@ -777,6 +791,11 @@ async function loadNetWorthSourceData(userId: number): Promise<NetWorthSourceDat
 
   return {
     rates,
+    historicalRateResolver: buildHistoricalCurrencyRateResolver(
+      await loadHistoricalCurrencyRateRows(),
+      rates,
+      BASE_CURRENCY,
+    ),
     savings: weighJointSavingsAccounts(jointScoped.savings),
     savingsTransactions: weighJointSavingsTransactions(
       jointScoped.savingsTransactions,
@@ -822,8 +841,72 @@ function buildFallbackNetWorthHistory(sourceData: NetWorthSourceData): NetWorthH
       year: new Date(currentMonth).getUTCFullYear(),
       totalValue,
       currency: BASE_CURRENCY,
+      fxEstimated: false,
     },
   ];
+}
+
+type NetWorthHistoryGroups = {
+  savingsByAccount: ReadonlyMap<number, readonly DatedSavingsTransaction[]>;
+  holdingsById: ReadonlyMap<number, readonly DatedHoldingTransaction[]>;
+  propertiesById: ReadonlyMap<number, readonly DatedPropertyTransaction[]>;
+  pensionsByPotId: ReadonlyMap<number, readonly DatedPensionTransaction[]>;
+  debtPaymentsByDebtId: ReadonlyMap<number, readonly DatedDebtPayment[]>;
+};
+
+type NetWorthHistoryMonth = ReturnType<typeof buildRollingMonths>[number];
+
+function computeNetWorthHistoryPoint(
+  sourceData: NetWorthSourceData,
+  groups: NetWorthHistoryGroups,
+  month: NetWorthHistoryMonth,
+  index: number,
+): NetWorthHistoryPoint {
+  const estimatedDateCountBefore =
+    sourceData.historicalRateResolver.getCoverage().estimatedDates.length;
+  const savings = computeSavingsAtCutoff(
+    sourceData.savings,
+    groups.savingsByAccount,
+    month.cutoff,
+    sourceData.historicalRateResolver,
+  );
+  const brokerage = computeBrokerageAtCutoff(
+    sourceData.holdings,
+    groups.holdingsById,
+    month.cutoff,
+    sourceData.historicalRateResolver,
+  );
+  const propertyEquity = computePropertyEquityAtCutoff(
+    sourceData.properties,
+    groups.propertiesById,
+    buildActiveMortgageBalanceAtCutoff(sourceData.mortgages, month.cutoff),
+    month.cutoff,
+    sourceData.historicalRateResolver,
+  );
+  const pension = computePensionAtCutoff(
+    sourceData.pensions,
+    groups.pensionsByPotId,
+    month.cutoff,
+    sourceData.historicalRateResolver,
+  );
+  const liabilities = computeDebtLiabilitiesAtCutoff(
+    sourceData.debts,
+    groups.debtPaymentsByDebtId,
+    month.cutoff,
+    sourceData.historicalRateResolver,
+  );
+  const fxEstimated =
+    sourceData.historicalRateResolver.getCoverage().estimatedDates.length >
+    estimatedDateCountBefore;
+
+  return {
+    id: index + 1,
+    month: month.label,
+    year: month.year,
+    totalValue: savings + brokerage + propertyEquity + pension - liabilities,
+    currency: BASE_CURRENCY,
+    fxEstimated,
+  };
 }
 
 export function buildNetWorthHistory(sourceData: NetWorthSourceData): NetWorthHistoryPoint[] {
@@ -842,68 +925,26 @@ export function buildNetWorthHistory(sourceData: NetWorthSourceData): NetWorthHi
   if (!hasQualifyingTransactions) return buildFallbackNetWorthHistory(sourceData);
 
   const months = buildRollingMonths();
-  const savingsByAccount = groupByNumericId(
-    datedSavingsTransactions,
-    (transaction) => transaction.accountId,
-  );
-  const holdingsById = groupByNumericId(
-    datedHoldingTransactions,
-    (transaction) => transaction.holdingId,
-  );
-  const propertiesById = groupByNumericId(
-    datedPropertyTransactions,
-    (transaction) => transaction.propertyId,
-  );
-  const pensionsByPotId = groupByNumericId(
-    datedPensionTransactions,
-    (transaction) => transaction.potId,
-  );
-  const debtPaymentsByDebtId = groupByNumericId(
-    datedDebtPayments,
-    (transaction) => transaction.debtId,
-  );
+  const groups: NetWorthHistoryGroups = {
+    savingsByAccount: groupByNumericId(
+      datedSavingsTransactions,
+      (transaction) => transaction.accountId,
+    ),
+    holdingsById: groupByNumericId(
+      datedHoldingTransactions,
+      (transaction) => transaction.holdingId,
+    ),
+    propertiesById: groupByNumericId(
+      datedPropertyTransactions,
+      (transaction) => transaction.propertyId,
+    ),
+    pensionsByPotId: groupByNumericId(datedPensionTransactions, (transaction) => transaction.potId),
+    debtPaymentsByDebtId: groupByNumericId(datedDebtPayments, (transaction) => transaction.debtId),
+  };
 
-  return months.map((month, index) => {
-    const savings = computeSavingsAtCutoff(
-      sourceData.savings,
-      savingsByAccount,
-      month.cutoff,
-      sourceData.rates,
-    );
-    const brokerage = computeBrokerageAtCutoff(
-      sourceData.holdings,
-      holdingsById,
-      month.cutoff,
-      sourceData.rates,
-    );
-    const propertyEquity = computePropertyEquityAtCutoff(
-      sourceData.properties,
-      propertiesById,
-      buildActiveMortgageBalanceAtCutoff(sourceData.mortgages, month.cutoff),
-      month.cutoff,
-      sourceData.rates,
-    );
-    const pension = computePensionAtCutoff(
-      sourceData.pensions,
-      pensionsByPotId,
-      month.cutoff,
-      sourceData.rates,
-    );
-    const liabilities = computeDebtLiabilitiesAtCutoff(
-      sourceData.debts,
-      debtPaymentsByDebtId,
-      month.cutoff,
-      sourceData.rates,
-    );
-
-    return {
-      id: index + 1,
-      month: month.label,
-      year: month.year,
-      totalValue: savings + brokerage + propertyEquity + pension - liabilities,
-      currency: BASE_CURRENCY,
-    };
-  });
+  return months.map((month, index) =>
+    computeNetWorthHistoryPoint(sourceData, groups, month, index),
+  );
 }
 
 app.get('/net-worth', async (c) => {

--- a/packages/frontend/src/features/dashboard/components/DashboardChartsGrid.tsx
+++ b/packages/frontend/src/features/dashboard/components/DashboardChartsGrid.tsx
@@ -25,7 +25,11 @@ export function DashboardChartsGrid({
         <AreaChartCard
           className="h-full"
           title="Net Worth Growth"
-          subtitle={`Last 7 months in ${baseCurrency}`}
+          subtitle={
+            chartData.some((point) => point.fxEstimated)
+              ? `Last 7 months in ${baseCurrency}; some FX values estimated from nearest available rates`
+              : `Last 7 months in ${baseCurrency}`
+          }
           data={chartData}
           dataKey="value"
           xKey="month"

--- a/packages/frontend/src/features/dashboard/types.ts
+++ b/packages/frontend/src/features/dashboard/types.ts
@@ -77,4 +77,9 @@ export type DashboardTxnStats = {
   totalSavingsDeposited: number;
 };
 
-export type NetWorthMetricData = { month: string; year: number; value: number };
+export type NetWorthMetricData = {
+  month: string;
+  year: number;
+  value: number;
+  fxEstimated?: boolean;
+};

--- a/packages/frontend/src/features/dashboard/utils/dashboard-data.ts
+++ b/packages/frontend/src/features/dashboard/utils/dashboard-data.ts
@@ -120,6 +120,7 @@ export function normalizeNetWorthSnapshots(
     month: snapshot.month,
     year: snapshot.year,
     value: convertToBase(snapshot.totalValue, snapshot.currency),
+    fxEstimated: snapshot.fxEstimated,
   }));
 }
 

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -635,6 +635,7 @@ export type NetWorthSnapshot = {
   year: number;
   totalValue: number;
   currency: CurrencyCode;
+  fxEstimated?: boolean;
 };
 
 export type AssetAllocation = {


### PR DESCRIPTION
## Summary
- Adds a dedicated `currency_rate_history` table keyed by currency pair and rate date, separate from the current-rate cache.
- Stores every successful current FX sync into history as a forward-collection strategy.
- Applies dated FX conversion to the dashboard net-worth history using the nearest previous historical rate, with current-rate fallback only when no history exists.
- Surfaces estimated FX values in the net-worth chart subtitle and adds resolver tests for nearest-previous and missing-history fallback behaviour.

Closes #75

## Scope decisions
- Selected chart for this PR: dashboard net-worth history.
- Backfill strategy: collect forward from successful current FX syncs; no historical provider backfill in this change.
- Missing-date policy: use nearest previous historical rate; if none exists, fall back to current rates and mark the point as estimated.

## Test Plan
- [x] `bun run typecheck`
- [x] `bun run lint` (passes with existing warnings)
- [x] `bun run build`
- [ ] `NODE_ENV=test bun test src/lib/currencyRateHistory.test.ts` (blocked locally: Bun 1.3.14 crashes with SIGILL/segfault on this VM before executing tests)
- [ ] `bun run db:migrate` (blocked locally by the same Bun SIGILL/segfault)
